### PR TITLE
core plugin: support set request timeout

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -53,9 +53,8 @@ pub static RTX_JOBS: Lazy<usize> = Lazy::new(|| {
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(4)
 });
-pub static RTX_FETCH_REMOTE_VERSIONS_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
-    var_duration("RTX_FETCH_REMOTE_VERSIONS_TIMEOUT").unwrap_or(Duration::from_secs(10))
-});
+pub static RTX_TIMEOUT: Lazy<Duration> =
+    Lazy::new(|| var_duration("RTX_TIMEOUT").unwrap_or(Duration::from_secs(30)));
 
 /// duration that remote version cache is kept for
 /// for "fast" commands (represented by PREFER_STALE), these are always

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,6 +13,7 @@ impl Client {
         let reqwest = reqwest::blocking::ClientBuilder::new()
             .user_agent(format!("rtx/{}", env!("CARGO_PKG_VERSION")))
             .gzip(true)
+            .timeout(*crate::env::RTX_TIMEOUT)
             .build()?;
         Ok(Self { reqwest })
     }

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -86,6 +86,6 @@ impl CorePlugin {
         F: FnOnce() -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        run_with_timeout(f, *env::RTX_FETCH_REMOTE_VERSIONS_TIMEOUT)
+        run_with_timeout(f, *env::RTX_TIMEOUT)
     }
 }

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -13,7 +13,7 @@ use once_cell::sync::Lazy;
 
 use crate::cache::CacheManager;
 use crate::config::{Config, Settings};
-use crate::env::RTX_FETCH_REMOTE_VERSIONS_TIMEOUT;
+use crate::env::RTX_TIMEOUT;
 use crate::env_diff::{EnvDiff, EnvDiffOperation};
 use crate::errors::Error::PluginNotInstalled;
 use crate::file::remove_all;
@@ -132,7 +132,7 @@ impl ExternalPlugin {
                 let result = cmd.stdout_capture().stderr_capture().unchecked().run()?;
                 Ok(result)
             },
-            *RTX_FETCH_REMOTE_VERSIONS_TIMEOUT,
+            *RTX_TIMEOUT,
         )
         .map_err(|err| {
             let script = self.script_man.get_script_path(&Script::ListAll);


### PR DESCRIPTION
default timeout is 30s  before this change,  to avoid breaking changes, take the larger of the two values.


fix #700