### PR TITLE
clean up logging env var logic

### DIFF
--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -72,7 +72,7 @@ impl HookEnv {
             .rev()
             .map(|(_, v)| v.to_string())
             .collect_vec();
-        if !installed_versions.is_empty() && !*env::RTX_QUIET {
+        if !installed_versions.is_empty() {
             let w = match terminal_size() {
                 Some((Width(w), _)) => w,
                 None => 80,

--- a/src/env.rs
+++ b/src/env.rs
@@ -343,6 +343,15 @@ fn log_level() -> LevelFilter {
         if arg == "--" {
             break;
         }
+        if arg == "--debug" {
+            set_var("RTX_LOG_LEVEL", "debug");
+            set_var("RTX_DEBUG", "1");
+        }
+        if arg == "--trace" {
+            set_var("RTX_LOG_LEVEL", "trace");
+            set_var("RTX_DEBUG", "1");
+            set_var("RTX_TRACE", "1");
+        }
         if let Some(("--log-level", level)) = arg.split_once('=') {
             set_var("RTX_LOG_LEVEL", level);
         }
@@ -350,12 +359,6 @@ fn log_level() -> LevelFilter {
             if let Some(level) = ARGS.get(i + 1) {
                 set_var("RTX_LOG_LEVEL", level);
             }
-        }
-        if arg == "--debug" {
-            set_var("RTX_DEBUG", "1");
-        }
-        if arg == "--trace" {
-            set_var("RTX_TRACE", "1");
         }
     }
     let log_level = var("RTX_LOG_LEVEL").unwrap_or_default();

--- a/src/env.rs
+++ b/src/env.rs
@@ -45,11 +45,8 @@ pub static RTX_LOG_LEVEL: Lazy<LevelFilter> = Lazy::new(log_level);
 pub static RTX_LOG_FILE_LEVEL: Lazy<LevelFilter> = Lazy::new(log_file_level);
 pub static RTX_MISSING_RUNTIME_BEHAVIOR: Lazy<Option<String>> =
     Lazy::new(|| var("RTX_MISSING_RUNTIME_BEHAVIOR").ok());
-pub static RTX_QUIET: Lazy<bool> = Lazy::new(|| var_is_true("RTX_QUIET"));
-pub static RTX_DEBUG: Lazy<bool> = Lazy::new(|| var_is_true("RTX_DEBUG"));
-pub static RTX_TRACE: Lazy<bool> = Lazy::new(|| var_is_true("RTX_TRACE"));
 pub static RTX_VERBOSE: Lazy<bool> =
-    Lazy::new(|| *RTX_DEBUG || *RTX_TRACE || var_is_true("RTX_VERBOSE"));
+    Lazy::new(|| *RTX_LOG_LEVEL > LevelFilter::Info || var_is_true("RTX_VERBOSE"));
 pub static RTX_JOBS: Lazy<usize> = Lazy::new(|| {
     var("RTX_JOBS")
         .ok()
@@ -339,18 +336,18 @@ fn prefer_stale(args: &[String]) -> bool {
 }
 
 fn log_level() -> LevelFilter {
+    if var_is_true("RTX_QUIET") {
+        set_var("RTX_LOG_LEVEL", "warn");
+    }
+    if var_is_true("RTX_DEBUG") {
+        set_var("RTX_LOG_LEVEL", "debug");
+    }
+    if var_is_true("RTX_TRACE") {
+        set_var("RTX_LOG_LEVEL", "trace");
+    }
     for (i, arg) in ARGS.iter().enumerate() {
         if arg == "--" {
             break;
-        }
-        if arg == "--debug" {
-            set_var("RTX_LOG_LEVEL", "debug");
-            set_var("RTX_DEBUG", "1");
-        }
-        if arg == "--trace" {
-            set_var("RTX_LOG_LEVEL", "trace");
-            set_var("RTX_DEBUG", "1");
-            set_var("RTX_TRACE", "1");
         }
         if let Some(("--log-level", level)) = arg.split_once('=') {
             set_var("RTX_LOG_LEVEL", level);
@@ -360,22 +357,30 @@ fn log_level() -> LevelFilter {
                 set_var("RTX_LOG_LEVEL", level);
             }
         }
-    }
-    let log_level = var("RTX_LOG_LEVEL").unwrap_or_default();
-    match log_level.parse::<LevelFilter>() {
-        Ok(level) => level,
-        _ => {
-            if *RTX_TRACE {
-                LevelFilter::Trace
-            } else if *RTX_DEBUG {
-                LevelFilter::Debug
-            } else if *RTX_QUIET {
-                LevelFilter::Warn
-            } else {
-                LevelFilter::Info
-            }
+        if arg == "--debug" {
+            set_var("RTX_LOG_LEVEL", "debug");
+        }
+        if arg == "--trace" {
+            set_var("RTX_LOG_LEVEL", "trace");
         }
     }
+    let log_level = var("RTX_LOG_LEVEL")
+        .unwrap_or_default()
+        .parse::<LevelFilter>()
+        .unwrap_or(LevelFilter::Info);
+    // set RTX_DEBUG/RTX_TRACE for plugins to use
+    match log_level {
+        LevelFilter::Trace => {
+            set_var("RTX_TRACE", "1");
+            set_var("RTX_DEBUG", "1");
+        }
+        LevelFilter::Debug => {
+            set_var("RTX_DEBUG", "1");
+        }
+        _ => {}
+    }
+
+    log_level
 }
 
 fn log_file_level() -> LevelFilter {


### PR DESCRIPTION
Main purpose is to ensure that RTX_DEBUG/RTX_TRACE are available in plugins
