### PR TITLE
add support for macos integration

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -15,9 +15,9 @@ The code for this is inside the rtx repository at
 The following installs the latest version of java-openjdk-17.x (if some version of openjdk-17.x is 
 not already installed) and makes it the global default:
 
-```sh
-rtx use -g java@openjdk-17
-rtx use -g java@17         # alternate shorthands for openjdk-only
+```sh-session
+$ rtx use -g java@openjdk-17
+$ rtx use -g java@17         # alternate shorthands for openjdk-only
 ```
 
 See available versions with `rtx ls-remote java`.
@@ -28,9 +28,9 @@ Some applications in macOS rely on `/usr/libexec/java_home` to find installed Ja
 
 To integrate an installed Java runtime with macOS run the following commands for the proper version (e.g. openjdk-20).
 
-```sh
-sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20
-sudo ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
+```sh-session
+$ sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20
+$ sudo ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
 ```
 
 The distribution from  Azul Systems does support the integration but the symlink target location will differ from the example above (e.g `~/.local/share/rtx/installs/java/zulu-11.64.190/zulu-11.jdk/Contents`).

--- a/docs/java.md
+++ b/docs/java.md
@@ -22,23 +22,15 @@ rtx use -g java@17         # alternate shorthands for openjdk-only
 
 See available versions with `rtx ls-remote java`.
 
-## Configuration
-
-- `RTX_JAVA_MACOS_INTEGRATION` [bool]: enables macOS JAVA_HOME integration, defaults to false
-
 ## macOS JAVA_HOME Integration
 
 Some applications in macOS rely on `/usr/libexec/java_home` to find installed Java runtimes.
 
-The environment variable `RTX_JAVA_MACOS_INTEGRATION` enables the integration during the installation. On removal
-the integration will be cleaned up regardless of the value of the environment variable.
-
-Since the integration relies on symlinks within `/Library/Java/JavaVirtualMachines`, administrative privileges are
-required when using this feature.
+To integrate an installed Java runtime with macOS run the following commands for the proper version (e.g. openjdk-20).
 
 ```sh
-sudo RTX_JAVA_MACOS_INTEGRATION=true rtx install java@openjdk-20
+sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20
+ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
 ```
 
-> Note: Not all distributions of Java SDK support this integration (e.g liberica). The integration will be simply
-> ignored in such cases even if the environment variable is set to true.
+> Note: Not all distributions of Java SDK support this integration (e.g liberica).

--- a/docs/java.md
+++ b/docs/java.md
@@ -33,4 +33,6 @@ sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20
 sudo ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
 ```
 
-> Note: Not all distributions of Java SDK support this integration (e.g liberica).
+The distribution from  Azul Systems does support the integration but the symlink target location will differ from the example above (e.g `~/.local/share/rtx/installs/java/zulu-11.64.190/zulu-11.jdk/Contents`).
+
+> Note: Not all distributions of the Java SDK support this integration (e.g liberica).

--- a/docs/java.md
+++ b/docs/java.md
@@ -30,7 +30,7 @@ To integrate an installed Java runtime with macOS run the following commands for
 
 ```sh
 sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20
-ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
+sudo ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
 ```
 
 > Note: Not all distributions of Java SDK support this integration (e.g liberica).

--- a/docs/java.md
+++ b/docs/java.md
@@ -15,9 +15,30 @@ The code for this is inside the rtx repository at
 The following installs the latest version of java-openjdk-17.x (if some version of openjdk-17.x is 
 not already installed) and makes it the global default:
 
-```sh-session
-$ rtx use -g java@openjdk-17
-$ rtx use -g java@17         # alternate shorthands for openjdk-only
+```sh
+rtx use -g java@openjdk-17
+rtx use -g java@17         # alternate shorthands for openjdk-only
 ```
 
 See available versions with `rtx ls-remote java`.
+
+## Configuration
+
+- `RTX_JAVA_MACOS_INTEGRATION` [bool]: enables macOS JAVA_HOME integration, defaults to false
+
+## macOS JAVA_HOME Integration
+
+Some applications in macOS rely on `/usr/libexec/java_home` to find installed Java runtimes.
+
+The environment variable `RTX_JAVA_MACOS_INTEGRATION` enables the integration during the installation. On removal
+the integration will be cleaned up regardless of the value of the environment variable.
+
+Since the integration relies on symlinks within `/Library/Java/JavaVirtualMachines`, administrative privileges are
+required when using this feature.
+
+```sh
+sudo RTX_JAVA_MACOS_INTEGRATION=true rtx install java@openjdk-20
+```
+
+> Note: Not all distributions of Java SDK support this integration (e.g liberica). The integration will be simply
+> ignored in such cases even if the environment variable is set to true.

--- a/docs/java.md
+++ b/docs/java.md
@@ -29,8 +29,8 @@ Some applications in macOS rely on `/usr/libexec/java_home` to find installed Ja
 To integrate an installed Java runtime with macOS run the following commands for the proper version (e.g. openjdk-20).
 
 ```sh-session
-$ sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20
-$ sudo ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20/Contents
+$ sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20.jdk
+$ sudo ln -s ~/.local/share/rtx/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20.jdk/Contents
 ```
 
 The distribution from  Azul Systems does support the integration but the symlink target location will differ from the example above (e.g `~/.local/share/rtx/installs/java/zulu-11.64.190/zulu-11.jdk/Contents`).

--- a/src/env.rs
+++ b/src/env.rs
@@ -204,10 +204,6 @@ pub static RTX_GO_SET_GOROOT: Lazy<Option<bool>> =
 pub static RTX_GO_SET_GOPATH: Lazy<Option<bool>> =
     Lazy::new(|| var_option_bool("RTX_GO_SET_GOPATH"));
 
-// java
-pub static RTX_JAVA_MACOS_INTEGRATION: Lazy<Option<bool>> =
-    Lazy::new(|| var_option_bool("RTX_JAVA_MACOS_INTEGRATION"));
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Confirm {
     Yes,

--- a/src/env.rs
+++ b/src/env.rs
@@ -204,6 +204,10 @@ pub static RTX_GO_SET_GOROOT: Lazy<Option<bool>> =
 pub static RTX_GO_SET_GOPATH: Lazy<Option<bool>> =
     Lazy::new(|| var_option_bool("RTX_GO_SET_GOPATH"));
 
+// java
+pub static RTX_JAVA_MACOS_INTEGRATION: Lazy<Option<bool>> =
+    Lazy::new(|| var_option_bool("RTX_JAVA_MACOS_INTEGRATION"));
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Confirm {
     Yes,

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -4,6 +4,7 @@ use std::fs::{self};
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{eyre, Result};
+use indoc::formatdoc;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use serde_derive::{Deserialize, Serialize};
@@ -175,12 +176,15 @@ impl JavaPlugin {
                 &tv.install_path().join("Contents").join("Home"),
             )?;
             info!(
-                "To enable macOS integration, run the following commands:\n\
-              sudo mkdir /Library/Java/JavaVirtualMachines/{}.jdk;\n\
-              sudo ln -s {}/Contents /Library/Java/JavaVirtualMachines/{}.jdk/Contents;\n",
-                tv.version,
-                tv.install_path().display(),
-                tv.version
+                "{}",
+                formatdoc! {r#"
+                To enable macOS integration, run the following commands:
+                sudo mkdir /Library/Java/JavaVirtualMachines/{version}.jdk
+                sudo ln -s {path}/Contents /Library/Java/JavaVirtualMachines/{version}.jdk/Contents
+                "#,
+                    version = tv.version,
+                    path = tv.install_path().display(),
+                }
             );
         }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -157,11 +157,12 @@ impl JavaPlugin {
             file::rename(entry.path(), dest)?;
         }
 
+        // move Contents dir to install path for macOS, if it exists
         if os() == "macosx" && contents_dir.exists() {
             file::create_dir_all(tv.install_path().join("Contents"))?;
             for entry in fs::read_dir(contents_dir)? {
                 let entry = entry?;
-                // if entry.path().to_string_lossy().contains("/Home") {
+                // skip Home dir, so we can symlink it later
                 if entry.file_name() == "Home" {
                     continue;
                 }

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
-use std::fs;
+use std::fs::{self, create_dir_all, remove_dir_all};
 use std::path::{Path, PathBuf};
 
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::{eyre, Context, Result};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use serde_derive::{Deserialize, Serialize};
@@ -74,6 +74,7 @@ impl JavaPlugin {
             })
         })
     }
+
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
         let versions = self
             .fetch_java_metadata("ga")?
@@ -94,13 +95,13 @@ impl JavaPlugin {
     }
 
     fn java_bin(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join("bin/java")
+        java_home_path(tv).join("bin/java")
     }
 
     fn test_java(&self, config: &Config, tv: &ToolVersion, pr: &ProgressReport) -> Result<()> {
         CmdLineRunner::new(&config.settings, self.java_bin(tv))
             .with_pr(pr)
-            .env("JAVA_HOME", tv.install_path())
+            .env("JAVA_HOME", java_home_path(tv))
             .arg("-version")
             .execute()
     }
@@ -133,18 +134,14 @@ impl JavaPlugin {
         }
         self.move_to_install_path(tv, m)
     }
-    fn move_to_install_path(&self, tv: &ToolVersion, m: &JavaMetadata) -> Result<()> {
-        let basedir = tv
+
+    fn move_to_install_path(&self, tv: &ToolVersion, _m: &JavaMetadata) -> Result<()> {
+        let source_dir = tv
             .download_path()
             .read_dir()?
             .find(|e| e.as_ref().unwrap().file_type().unwrap().is_dir())
             .unwrap()?
             .path();
-        let source_dir = match m.vendor.as_str() {
-            "zulu" | "liberica" => basedir,
-            _ if os() == "macosx" => basedir.join("Contents").join("Home"),
-            _ => basedir,
-        };
         file::remove_all(tv.install_path())?;
         file::create_dir_all(tv.install_path())?;
         for entry in fs::read_dir(source_dir)? {
@@ -153,6 +150,38 @@ impl JavaPlugin {
             trace!("moving {:?} to {:?}", entry.path(), &dest);
             file::rename(entry.path(), dest)?;
         }
+        Ok(())
+    }
+
+    fn install_macos_integration(&self, tv: &ToolVersion) -> Result<()> {
+        let macos_jvm_integration = Path::new("/Library/Java/JavaVirtualMachines");
+        create_dir_all(macos_jvm_integration.join(tv.version.clone())).with_context(|| {
+            eyre!(
+                "Unable to enable Java macOS integration for {}. Try using command with sudo.",
+                tv.version
+            )
+        })?;
+        file::make_symlink(
+            tv.install_path().join("Contents").as_path(),
+            macos_jvm_integration
+                .join(tv.version.clone())
+                .join("Contents")
+                .as_path(),
+        )?;
+        Ok(())
+    }
+
+    fn uninstall_macos_integration(&self, tv: &ToolVersion) -> Result<()> {
+        let macos_jvm_integration =
+            Path::new("/Library/Java/JavaVirtualMachines").join(tv.version.clone());
+        macos_jvm_integration.exists().then(|| {
+            remove_dir_all(macos_jvm_integration).with_context(|| {
+                eyre!(
+                    "Unable to remove Java macOS integration for {}. Try using command with sudo.",
+                    tv.version
+                )
+            })
+        });
         Ok(())
     }
 
@@ -220,8 +249,20 @@ impl Plugin for JavaPlugin {
 
         let metadata = self.tv_to_metadata(tv)?;
         let tarball_path = self.download(tv, pr, metadata)?;
+
         self.install(tv, pr, &tarball_path, metadata)?;
+        if *env::RTX_JAVA_MACOS_INTEGRATION == Some(true) && supports_macos_integration(tv) {
+            self.install_macos_integration(tv)?;
+        }
         self.verify(config, tv, pr)?;
+
+        Ok(())
+    }
+
+    fn uninstall_version(&self, _config: &Config, tv: &ToolVersion) -> Result<()> {
+        if supports_macos_integration(tv) {
+            self.uninstall_macos_integration(tv)?;
+        }
 
         Ok(())
     }
@@ -229,7 +270,7 @@ impl Plugin for JavaPlugin {
     fn exec_env(&self, _config: &Config, tv: &ToolVersion) -> Result<HashMap<String, String>> {
         let map = HashMap::from([(
             "JAVA_HOME".into(),
-            tv.install_path().to_string_lossy().into(),
+            java_home_path(tv).to_string_lossy().into(),
         )]);
         Ok(map)
     }
@@ -252,6 +293,28 @@ impl Plugin for JavaPlugin {
         } else {
             Ok(contents)
         }
+    }
+}
+
+fn supports_macos_integration(tv: &ToolVersion) -> bool {
+    let is_enabled = *env::RTX_JAVA_MACOS_INTEGRATION == Some(true);
+    let is_unsupported = ["liberica-"].iter().any(|&s| tv.version.starts_with(s));
+
+    if os() == "macosx" && is_enabled && !is_unsupported {
+        return true;
+    }
+    false
+}
+
+fn java_home_path(tv: &ToolVersion) -> PathBuf {
+    if os() == "macosx" {
+        if tv.install_path().join("Contents/Home").exists() {
+            tv.install_path().join("Contents/Home")
+        } else {
+            tv.install_path()
+        }
+    } else {
+        tv.install_path()
     }
 }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -175,9 +175,9 @@ impl JavaPlugin {
                 &tv.install_path().join("Contents").join("Home"),
             )?;
             info!(
-                "To enable macOS integration, run the following commands: \
-              sudo mkdir /Library/Java/JavaVirtualMachines/{}; \
-              sudo ln -s {}/Contents /Library/Java/JavaVirtualMachines/{}/Contents;\n",
+                "To enable macOS integration, run the following commands:\n\
+              sudo mkdir /Library/Java/JavaVirtualMachines/{}.jdk;\n\
+              sudo ln -s {}/Contents /Library/Java/JavaVirtualMachines/{}.jdk/Contents;\n",
                 tv.version,
                 tv.install_path().display(),
                 tv.version


### PR DESCRIPTION
This is first rough draft. Which works with with `sudo`, what i currently don't like yet is that using `sudo` installs the JDK with `root` as the owner which currently fails with an unspecific error (since installation is removed before the symlink remove is attempted). Having root as owner potentially leads to other issues as well.

```
$ sudo env RTX_JAVA_MACOS_INTEGRATION=true .bin/rtx install java@corretto-20.0.2.10.1
$ /usr/libexec/java_home -V
$ sudo env .bin/rtx uninstall java@corretto-20.0.2.10.1
$ /usr/libexec/java_home -V
```