### PR TITLE
Avoid panic if run_with_timeout hits timeout.

### DIFF
--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -11,7 +11,8 @@ where
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         let result = f();
-        tx.send(result).unwrap();
+        // If sending fails, the timeout has already been reached.
+        let _ = tx.send(result);
     });
     rx.recv_timeout(timeout).context("timed out")?
 }


### PR DESCRIPTION
If run_with_timeout hits the timeout, the mpsc receiver may be dropped, leading to a panic when the background thread later attempts to return its value.

This change simply ignores any error. Since the timeout has already been reached, reporting on this error would just be noise.

A future improvement could be to cancel the background operation, but that would require a much larger refactoring.

Part of #860
