### PR TITLE
feat(zsh): added support for custom $ZDOTDIR

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -138,7 +138,7 @@ after_finish_help() {
 	case "${SHELL:-}" in
 	*/zsh)
 		info "rtx: run the following to activate rtx in your shell:"
-		info "echo \"eval \\\"\\\$($install_path activate zsh)\\\"\" >> ~/.zshrc"
+		info "echo \"eval \\\"\\\$($install_path activate zsh)\\\"\" >> \"${ZDOTDIR-~}/.zshrc\""
 		info ""
 		info "rtx: this must be run in order to use rtx in the terminal"
 		info "rtx: run \`rtx doctor\` to verify this is setup correctly"


### PR DESCRIPTION
:warning: I haven't figured out how to build the install.sh and test this.

https://zsh.sourceforge.io/Intro/intro_3.html

## Steps to test
1. run `ZDOTDIR="~/.zsh" install.sh`

## New result

```
rtx: run the following to activate rtx in your shell:
echo "eval \"\$(/home/superuser/.local/share/rtx/bin/rtx activate zsh)\"" >> "~/.zsh/.zshrc"
```

## Old result

```
rtx: run the following to activate rtx in your shell:
echo "eval \"\$(/home/superuser/.local/share/rtx/bin/rtx activate zsh)\"" >> ~/.zshrc
```