### PR TITLE
fix(nushell): Use extern-wrapped instead of def-env and $env instead of let-env

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -60,7 +60,7 @@ impl Shell for Nushell {
             $in | lines | parse "{{op}},{{name}},{{value}}"
           }}
             
-          extern-wrapped rtx [command?: string, --help, ...rest: string] {{
+          def --wrapped rtx [command?: string, --help, ...rest: string] {{
             let commands = ["shell", "deactivate"]
             
             if ($command == null) {{

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -66,7 +66,7 @@ impl Shell for Nushell {
             if ($command == null) {{
               ^"{exe}"
             }} else if ($command == "activate") {{
-              let-env RTX_SHELL = "nu"
+              $env.RTX_SHELL = "nu"
             }} else if ($command in $commands) {{
               ^"{exe}" $command $rest
               | parse vars

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -60,7 +60,7 @@ impl Shell for Nushell {
             $in | lines | parse "{{op}},{{name}},{{value}}"
           }}
             
-          def-env rtx [command?: string, --help, ...rest: string] {{
+          extern-wrapped rtx [command?: string, --help, ...rest: string] {{
             let commands = ["shell", "deactivate"]
             
             if ($command == null) {{

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init.snap
@@ -26,13 +26,13 @@ def "parse vars" [] {
   $in | lines | parse "{op},{name},{value}"
 }
   
-def-env rtx [command?: string, --help, ...rest: string] {
+def --wrapped rtx [command?: string, --help, ...rest: string] {
   let commands = ["shell", "deactivate"]
   
   if ($command == null) {
     ^"/some/dir/rtx"
   } else if ($command == "activate") {
-    let-env RTX_SHELL = "nu"
+    $env.RTX_SHELL = "nu"
   } else if ($command in $commands) {
     ^"/some/dir/rtx" $command $rest
     | parse vars

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
@@ -25,13 +25,13 @@ def "parse vars" [] {
   $in | lines | parse "{op},{name},{value}"
 }
   
-def-env rtx [command?: string, --help, ...rest: string] {
+def --wrapped rtx [command?: string, --help, ...rest: string] {
   let commands = ["shell", "deactivate"]
   
   if ($command == null) {
     ^"/nix/store/rtx"
   } else if ($command == "activate") {
-    let-env RTX_SHELL = "nu"
+    $env.RTX_SHELL = "nu"
   } else if ($command in $commands) {
     ^"/nix/store/rtx" $command $rest
     | parse vars


### PR DESCRIPTION
Should fix https://github.com/jdx/rtx/issues/514 and https://github.com/jdx/rtx/issues/960.

My original fix was to use `extern-wrapped`, but that will be deprecated in the next release of Nushell, so I opted for [`def --wrapped` which was added in nushell 0.86 released three weeks ago](https://www.nushell.sh/blog/2023-10-17-nushell_0_86.html#unified-command-definitions).

If you want more backstory, see [this thread in the Nushell DIscord](https://discord.com/channels/601130461678272522/1167041447090991174/1167041447090991174).