### PR TITLE
fix: xonsh hook

### DIFF
--- a/src/shell/snapshots/rtx__shell__xonsh__tests__unset_env.snap
+++ b/src/shell/snapshots/rtx__shell__xonsh__tests__unset_env.snap
@@ -6,6 +6,6 @@ from os               import environ
 from xonsh.built_ins  import XSH
 
 envx = XSH.env
-envx.pop[   'FOO',None]
-environ.pop['FOO',None]
+envx.pop(   'FOO',None)
+environ.pop('FOO',None)
 

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -115,8 +115,8 @@ impl Shell for Xonsh {
             from xonsh.built_ins  import XSH
 
             envx = XSH.env
-            envx.pop[   '{k}',None]
-            environ.pop['{k}',None]
+            envx.pop(   '{k}',None)
+            environ.pop('{k}',None)
         "#,
             k = shell_escape::unix::escape(k.into()) // todo: drop illegal chars, not escape?
         )


### PR DESCRIPTION
It was raising a TypeError:

```
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
TypeError: 'method' object is not subscriptable
Exception raised in event handler; ignored.
```

I was able to build, but running the tests failed with `fatal runtime error: failed to initiate panic, error 5`. I have been using the debug build and it solves the problems.