### PR TITLE
Update README.md: add hint for section asdf to rtx

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Features
 
-- **asdf-compatible** - rtx is compatible with asdf plugins and `.tool-versions` files. It can be used as a drop-in replacement.
+- **asdf-compatible** - rtx is compatible with asdf plugins and `.tool-versions` files. It can be used as a drop-in replacement. [See below for migration instructions](#how-do-i-migrate-from-asdf)
 - **Polyglot** - compatible with any language, so no more figuring out how nvm, nodenv, pyenv, etc work individually—just use 1 tool.
 - **Fast** - rtx is written in Rust and is very fast. 20x-200x faster than asdf.
 - **No shims** - shims cause problems, they break `which`, and add overhead. By default, rtx
@@ -63,8 +63,6 @@ $ rtx use --global node@20
 $ node -v
 v20.0.0
 ```
-
-**Note:** If you're moving from asdf to rtx, please review [How do I migrate from asdf?](#how-do-i-migrate-from-asdf) for guidance.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ echo 'eval "$(~/bin/rtx activate zsh)"' >> ~/.zshrc
 echo '~/bin/rtx activate fish | source' >> ~/.config/fish/config.fish
 ```
 
+Note: If you're moving from asdf to rtx, please review [How do I migrate from asdf?](#how-do-i-migrate-from-asdf) for guidance.
+
 > **Warning**
 >
 > If you use direnv with `layout python` or other logic that needs to reference rtx runtimes inside
@@ -497,6 +499,10 @@ in this project.
 [See here](https://github.com/jdx/rtx/tree/main/src/shell) for how
 the others are implemented. If your shell isn't currently supported
 I'd be happy to help you get yours integrated.
+
+## Migrate from asdf
+
+If you're moving from asdf to rtx, please review [How do I migrate from asdf?](#how-do-i-migrate-from-asdf) for guidance.
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ echo 'eval "$(~/bin/rtx activate zsh)"' >> ~/.zshrc
 echo '~/bin/rtx activate fish | source' >> ~/.config/fish/config.fish
 ```
 
-Note: If you're moving from asdf to rtx, please review [How do I migrate from asdf?](#how-do-i-migrate-from-asdf) for guidance.
-
 > **Warning**
 >
 > If you use direnv with `layout python` or other logic that needs to reference rtx runtimes inside
@@ -65,6 +63,8 @@ $ rtx use --global node@20
 $ node -v
 v20.0.0
 ```
+
+**Note:** If you're moving from asdf to rtx, please review [How do I migrate from asdf?](#how-do-i-migrate-from-asdf) for guidance.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ in this project.
 the others are implemented. If your shell isn't currently supported
 I'd be happy to help you get yours integrated.
 
-## Migrate from asdf
+### Migrate from asdf
 
 If you're moving from asdf to rtx, please review [How do I migrate from asdf?](#how-do-i-migrate-from-asdf) for guidance.
 


### PR DESCRIPTION
add hint for section asdf to rtx

Since rtx main claim is to replace asdf, there should be more visible the steps a user need to change, if they have previous installed asdf.