### PR TITLE
ignore -SNAPSHOT versions

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -376,7 +376,7 @@ impl Tool {
         }
         let query_regex = Regex::new(&format!("^{}([-.].+)?$", query))?;
         let version_regex = regex!(
-            r"(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)"
+            r"(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|SNAPSHOT|master)"
         );
         let versions = versions
             .into_iter()


### PR DESCRIPTION
This filters out versions that should be ignored from prefix matches.

Fixes #957
