### PR TITLE
migrate: remove deprecated non-core plugins

### DIFF
--- a/e2e/test_nodejs
+++ b/e2e/test_nodejs
@@ -11,8 +11,8 @@ assert_contains "rtx x node@lts/hydrogen -- node --version" "v18."
 assert "rtx x -- node --version" "v20.0.0"
 assert_contains "rtx node node-build --version" "node-build "
 
-# test rtx-nodejs
-rtx plugin i nodejs https://github.com/rtx-plugins/rtx-nodejs
+# test asdf-nodejs
+rtx plugin i nodejs https://github.com/asdf-vm/asdf-nodejs.git
 rtx use nodejs@20.1.0
 assert "rtx x -- node --version" "v20.1.0"
 assert_contains "rtx node nodebuild --version" "node-build "

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,7 @@ fn run(args: &Vec<String>) -> Result<()> {
 
     // show version before loading config in case of error
     cli::version::print_version_if_requested(&env::ARGS, out);
-    if let Err(err) = migrate::run() {
-        warn!("Error migrating: {}", err);
-    }
+    migrate::run();
 
     let config = Config::load()?;
     let config = shims::handle_shim(config, args, out)?;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,25 +1,31 @@
+use std::fs;
 use std::path::Path;
 
-use color_eyre::eyre::Result;
+use eyre::Result;
+use rayon::Scope;
 
 use crate::dirs::{CACHE, CONFIG, INSTALLS, PLUGINS, ROOT};
 use crate::file;
 
-pub fn run() -> Result<()> {
-    move_subdirs(&INSTALLS.join("nodejs"), &INSTALLS.join("node"))?;
-    move_subdirs(&INSTALLS.join("golang"), &INSTALLS.join("go"))?;
-    move_subdirs(&PLUGINS.join("nodejs"), &PLUGINS.join("node"))?;
-    move_subdirs(&PLUGINS.join("golang"), &PLUGINS.join("go"))?;
-    move_dirs(
-        &CACHE.join("trusted-configs"),
-        &ROOT.join("trusted-configs"),
-    )?;
-    move_dirs(
-        &CONFIG.join("trusted-configs"),
-        &ROOT.join("trusted-configs"),
-    )?;
+pub fn run() {
+    rayon::scope(|s| {
+        task(s, || rename_plugin("nodejs", "node"));
+        task(s, || rename_plugin("golang", "go"));
+        task(s, migrate_trusted_configs);
+        task(s, || remove_deprecated_plugin("node", "rtx-nodejs"));
+        task(s, || remove_deprecated_plugin("python", "rtx-golang"));
+        task(s, || remove_deprecated_plugin("python", "rtx-java"));
+        task(s, || remove_deprecated_plugin("python", "rtx-python"));
+        task(s, || remove_deprecated_plugin("python", "rtx-ruby"));
+    });
+}
 
-    Ok(())
+fn task(s: &Scope, job: impl FnOnce() -> Result<()> + Send + 'static) {
+    s.spawn(|_| {
+        if let Err(err) = job() {
+            warn!("migrate: {}", err);
+        }
+    });
 }
 
 fn move_subdirs(from: &Path, to: &Path) -> Result<()> {
@@ -41,11 +47,37 @@ fn move_subdirs(from: &Path, to: &Path) -> Result<()> {
     Ok(())
 }
 
+fn rename_plugin(from: &str, to: &str) -> Result<()> {
+    move_subdirs(&INSTALLS.join(from), &INSTALLS.join(to))?;
+    move_subdirs(&PLUGINS.join(from), &PLUGINS.join(to))?;
+    Ok(())
+}
+fn migrate_trusted_configs() -> Result<()> {
+    let cache_trusted_configs = CACHE.join("trusted-configs");
+    let config_trusted_configs = CONFIG.join("trusted-configs");
+    let root_trusted_configs = ROOT.join("trusted-configs");
+    move_dirs(&cache_trusted_configs, &root_trusted_configs)?;
+    move_dirs(&config_trusted_configs, &root_trusted_configs)?;
+    Ok(())
+}
+
 fn move_dirs(from: &Path, to: &Path) -> Result<()> {
     if from.exists() && !to.exists() {
         info!("migrating {} to {}", from.display(), to.display());
         file::create_dir_all(to.parent().unwrap())?;
         file::rename(from, to)?;
     }
+    Ok(())
+}
+
+fn remove_deprecated_plugin(name: &str, plugin_name: &str) -> Result<()> {
+    let plugin_root = PLUGINS.join(name);
+    let gitconfig = plugin_root.join(".git").join("config");
+    let gitconfig_body = fs::read_to_string(gitconfig).unwrap_or_default();
+    if !gitconfig_body.contains(&format!("github.com/rtx-plugins/{plugin_name}")) {
+        return Ok(());
+    }
+    info!("removing deprecated plugin {plugin_name}, will use core {name} plugin from now on");
+    file::remove_all(plugin_root)?;
     Ok(())
 }


### PR DESCRIPTION
If rtx-nodejs (or other deprecated plugins) is installed it should be removed in favor of the core plugins

See discussion in https://github.com/jdx/rtx/issues/956