### PR TITLE
Use def --env instead of def-env for Nushell script

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -76,7 +76,7 @@ impl Shell for Nushell {
             }}
           }}
             
-          def-env "update-env" [] {{
+          def --env "update-env" [] {{
             for $var in $in {{
               if $var.op == "set" {{
                 load-env {{($var.name): $var.value}}
@@ -86,7 +86,7 @@ impl Shell for Nushell {
             }}
           }}
             
-          def-env rtx_hook [] {{
+          def --env rtx_hook [] {{
             ^"{exe}" hook-env{status} -s nu
               | parse vars
               | update-env

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init.snap
@@ -42,7 +42,7 @@ def --wrapped rtx [command?: string, --help, ...rest: string] {
   }
 }
   
-def-env "update-env" [] {
+def --env "update-env" [] {
   for $var in $in {
     if $var.op == "set" {
       load-env {($var.name): $var.value}
@@ -52,7 +52,7 @@ def-env "update-env" [] {
   }
 }
   
-def-env rtx_hook [] {
+def --env rtx_hook [] {
   ^"/some/dir/rtx" hook-env --status -s nu
     | parse vars
     | update-env

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
@@ -41,7 +41,7 @@ def --wrapped rtx [command?: string, --help, ...rest: string] {
   }
 }
   
-def-env "update-env" [] {
+def --env "update-env" [] {
   for $var in $in {
     if $var.op == "set" {
       load-env {($var.name): $var.value}
@@ -51,7 +51,7 @@ def-env "update-env" [] {
   }
 }
   
-def-env rtx_hook [] {
+def --env rtx_hook [] {
   ^"/nix/store/rtx" hook-env --status -s nu
     | parse vars
     | update-env


### PR DESCRIPTION
Nushell has deprecated `def-env` in favor of `def --env`, so this PR is for making that replacement. `def-env` will be removed in 0.88, which will be released later on 12/12. I haven't actually tested this yet, though.