### PR TITLE
load installed/current plugins when installing plugins

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -8,3 +8,5 @@
 ruby/Gemfile
 ruby/.ruby-version
 Library
+/pyproject.toml
+/poetry.lock

--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -35,17 +35,17 @@ assert_path() {
 }
 
 test "$(node -v)" = "v20.0.0"
-assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
+assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/python/3.12.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/poetry/1.7.1/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 assert "$FOO" "cd"
 
 cd 18 && _rtx_hook
 test "$(node -v)" = "v18.0.0"
-assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/18.0.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
+assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/18.0.0/bin:INSTALLS/python/3.12.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/poetry/1.7.1/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 assert "$FOO" "18"
 
 cd .. && _rtx_hook
 test "$(node -v)" = "v20.0.0"
-assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
+assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/python/3.12.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/poetry/1.7.1/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 
 rtx shell node@18.0.0 && _rtx_hook
 test "$(node -v)" = "v18.0.0"

--- a/e2e/config/.e2e.rtx.toml
+++ b/e2e/config/.e2e.rtx.toml
@@ -5,7 +5,9 @@ env_path = ["/root", "./cwd"]
 FOO = "bar"
 
 [tools]
+python = "3.12.0"
 tiny = "latest"
+poetry = {version="1.7.1", pyproject="pyproject.toml"}
 #golang = {version="1.19.5", foo="bar"}
 
 [plugins]

--- a/e2e/config/pyproject.toml
+++ b/e2e/config/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "poetry-test"
+version = "0.1.0"
+description = ""
+authors = ["rtx"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -23,7 +23,7 @@ setup_env() {
 setup_config_files() {
 	mkdir -p "$ROOT/e2e/cd/18"
 	cp "$ROOT/e2e/config/".e2e.* "$ROOT/e2e/"
-	cp "$ROOT/e2e/config/"{.node-version,.alternate-tool-versions,.test-env} "$ROOT/e2e/"
+	cp "$ROOT/e2e/config/"{.node-version,.alternate-tool-versions,.test-env,pyproject.toml} "$ROOT/e2e/"
 	cp "$ROOT/e2e/config/cd/".e2e.* "$ROOT/e2e/cd/"
 	cp "$ROOT/e2e/config/cd/18/".e2e.* "$ROOT/e2e/cd/18"
 }

--- a/e2e/test_doctor
+++ b/e2e/test_doctor
@@ -11,5 +11,6 @@ assert() {
 	fi
 }
 
+rtx plugins install poetry && rtx i
 eval "$(rtx activate bash)" && _rtx_hook
 rtx doctor

--- a/e2e/test_local
+++ b/e2e/test_local
@@ -27,7 +27,9 @@ env_path = [\"/root\", \"./cwd\"]
 FOO = \"bar\"
 
 [tools]
+python = \"3.12.0\"
 tiny = \"latest\"
+poetry = {version=\"1.7.1\", pyproject=\"pyproject.toml\"}
 #golang = {version=\"1.19.5\", foo=\"bar\"}
 
 [plugins]
@@ -42,7 +44,9 @@ env_path = [\"/root\", \"./cwd\"]
 FOO = \"bar\"
 
 [tools]
+python = \"3.12.0\"
 tiny = \"latest\"
+poetry = {version=\"1.7.1\", pyproject=\"pyproject.toml\"}
 shfmt = \"3.5.0\"
 #golang = {version=\"1.19.5\", foo=\"bar\"}
 
@@ -66,7 +70,9 @@ env_path = [\"/root\", \"./cwd\"]
 FOO = \"bar\"
 
 [tools]
+python = \"3.12.0\"
 tiny = \"latest\"
+poetry = {version=\"1.7.1\", pyproject=\"pyproject.toml\"}
 shfmt = \"3.6.0\"
 #golang = {version=\"1.19.5\", foo=\"bar\"}
 
@@ -87,7 +93,9 @@ env_path = [\"/root\", \"./cwd\"]
 FOO = \"bar\"
 
 [tools]
+python = \"3.12.0\"
 tiny = \"latest\"
+poetry = {version=\"1.7.1\", pyproject=\"pyproject.toml\"}
 #golang = {version=\"1.19.5\", foo=\"bar\"}
 
 [plugins]

--- a/e2e/test_nodejs
+++ b/e2e/test_nodejs
@@ -16,12 +16,12 @@ assert_contains "rtx node node-build --version" "node-build "
 # test asdf-nodejs
 rtx plugin i nodejs https://github.com/asdf-vm/asdf-nodejs.git
 rtx use nodejs@20.1.0
+rtx ls
 assert "rtx x -- node --version" "v20.1.0"
 assert_contains "rtx node nodebuild --version" "node-build "
 rtx use --rm node
 
 # RTX_LEGACY_VERSION_FILE env var
-rtx ls
 RTX_LEGACY_VERSION_FILE=1 assert_contains "rtx current node" "20.0.0"
 RTX_LEGACY_VERSION_FILE=0 assert_not_contains "rtx current node" "20.0.0"
 rtx plugin uninstall nodejs

--- a/e2e/test_poetry
+++ b/e2e/test_poetry
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+rm -rf "$RTX_DATA_DIR/cache/poetry"
+
+export POETRY_HOME=".poetry"
+
+eval "$(rtx activate bash)"
+rtx i python
+rtx i poetry
+
+_rtx_hook
+assert "poetry --version" "Poetry (version 1.7.1)"
+python3 -V
+poetry install
+poetry env info
+assert "$(poetry env info -e) --version" "Python 3.12.0"
+assert "echo \$VIRTUAL_ENV" "$(poetry env info -p)"
+
+rm pyproject.toml

--- a/e2e/test_python
+++ b/e2e/test_python
@@ -6,5 +6,5 @@ source "$(dirname "$0")/assert.sh"
 export RTX_EXPERIMENTAL=1
 export RTX_PYTHON_DEFAULT_PACKAGES_FILE="$ROOT/e2e/.default-python-packages"
 
-rtx i python@3.11
-assert_contains "rtx x python@3.11 -- python --version" "Python 3.11"
+rtx i python@3.12.0
+assert_contains "rtx x python@3.12.0 -- python --version" "Python 3.12"

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -38,7 +38,7 @@ impl Which {
                 } else if self.plugin {
                     rtxprintln!(out, "{}", p.name);
                 } else {
-                    let path = p.which(&config, &tv, &self.bin_name)?;
+                    let path = p.which(&config, &ts, &tv, &self.bin_name)?;
                     rtxprintln!(out, "{}", path.unwrap().display());
                 }
                 Ok(())

--- a/src/install_context.rs
+++ b/src/install_context.rs
@@ -1,0 +1,11 @@
+use crate::config::Config;
+use crate::toolset::{ToolVersion, Toolset};
+use crate::ui::progress_report::ProgressReport;
+
+pub struct InstallContext<'a> {
+    pub config: &'a Config,
+    pub ts: &'a Toolset,
+    pub tv: ToolVersion,
+    pub pr: ProgressReport,
+    pub force: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ pub mod github;
 mod hash;
 mod hook_env;
 mod http;
+mod install_context;
 mod lock_file;
 mod logger;
 mod migrate;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -12,8 +12,9 @@ pub use script_manager::{Script, ScriptManager};
 use crate::config::{Config, Settings};
 use crate::file;
 use crate::file::display_path;
+use crate::install_context::InstallContext;
 use crate::lock_file::LockFile;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolVersion, Toolset};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::{ProgressReport, PROG_TEMPLATE};
 
@@ -81,15 +82,24 @@ pub trait Plugin: Debug + Send + Sync {
     ) -> Result<()> {
         unimplemented!()
     }
-    fn install_version(&self, config: &Config, tv: &ToolVersion, pr: &ProgressReport)
-        -> Result<()>;
+    fn install_version(&self, ctx: &InstallContext) -> Result<()>;
     fn uninstall_version(&self, _config: &Config, _tv: &ToolVersion) -> Result<()> {
         Ok(())
     }
-    fn list_bin_paths(&self, _config: &Config, tv: &ToolVersion) -> Result<Vec<PathBuf>> {
+    fn list_bin_paths(
+        &self,
+        _config: &Config,
+        _ts: &Toolset,
+        tv: &ToolVersion,
+    ) -> Result<Vec<PathBuf>> {
         Ok(vec![tv.install_path().join("bin")])
     }
-    fn exec_env(&self, _config: &Config, _tv: &ToolVersion) -> Result<HashMap<String, String>> {
+    fn exec_env(
+        &self,
+        _config: &Config,
+        _ts: &Toolset,
+        _tv: &ToolVersion,
+    ) -> Result<HashMap<String, String>> {
         Ok(HashMap::new())
     }
 

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -114,6 +114,14 @@ impl ScriptManager {
         self
     }
 
+    pub fn prepend_path(&mut self, path: PathBuf) {
+        let k: OsString = "PATH".into();
+        let mut paths = env::split_paths(&self.env[&k]).collect::<Vec<_>>();
+        paths.insert(0, path);
+        self.env
+            .insert("PATH".into(), env::join_paths(paths).unwrap());
+    }
+
     pub fn get_script_path(&self, script: &Script) -> PathBuf {
         match script {
             Script::RunExternalCommand(path, _) => path.clone(),


### PR DESCRIPTION
Possibly a cheap workaround for https://github.com/jdx/rtx/issues/393. It should make the following
possible:

    rtx install python
    rtx install poetry # poetry depends on python

If you were to just run `rtx install` and try to install python and
poetry at the same time it would not work, however.
