### PR TITLE
use: reuse existing versions

### DIFF
--- a/e2e/test_use
+++ b/e2e/test_use
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/assert.sh"
+
+rtx rm --all tiny
+rtx i tiny@1.0.0
+rtx use tiny@1
+assert "rtx current tiny" "1.0.0"

--- a/schema/rtx.json
+++ b/schema/rtx.json
@@ -196,6 +196,10 @@
         "verbose": {
           "description": "display installation output",
           "type": "boolean"
+        },
+        "yes": {
+          "description": "assume yes for all prompts",
+          "type": "boolean"
         }
       }
     }

--- a/src/cli/snapshots/rtx__cli__r#use__tests__use_local-2.snap
+++ b/src/cli/snapshots/rtx__cli__r#use__tests__use_local-2.snap
@@ -1,7 +1,7 @@
 ---
 source: src/cli/use.rs
-expression: "fs::read_to_string(&cf_path).unwrap()"
+expression: "file::read_to_string(&cf_path).unwrap()"
 ---
 [tools]
-tiny = "3.1.0"
+tiny = "2.1.0"
 

--- a/src/config/config_file/rtx_toml.rs
+++ b/src/config/config_file/rtx_toml.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -24,7 +24,7 @@ use crate::toolset::{
 use crate::ui::prompt;
 use crate::{dirs, env, file, parse_error};
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct RtxToml {
     context: Context,
     path: PathBuf,
@@ -766,6 +766,35 @@ impl ConfigFile for RtxToml {
 
     fn is_global(&self) -> bool {
         global_config_files().iter().any(|p| p == &self.path)
+    }
+}
+
+impl Debug for RtxToml {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("RtxToml");
+        d.field("path", &self.path)
+            .field("toolset", &self.toolset.to_string())
+            .field("is_trusted", &self.is_trusted)
+            .field("settings", &self.settings);
+        if let Some(env_file) = &self.env_file {
+            d.field("env_file", env_file);
+        }
+        if !self.env.is_empty() {
+            d.field("env", &self.env);
+        }
+        if !self.env_remove.is_empty() {
+            d.field("env_remove", &self.env_remove);
+        }
+        if !self.path_dirs.is_empty() {
+            d.field("path_dirs", &self.path_dirs);
+        }
+        if !self.alias.is_empty() {
+            d.field("alias", &self.alias);
+        }
+        if !self.plugins.is_empty() {
+            d.field("plugins", &self.plugins);
+        }
+        d.finish()
     }
 }
 

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-2.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-2.snap
@@ -3,29 +3,12 @@ source: src/config/config_file/rtx_toml.rs
 expression: cf.settings()
 ---
 SettingsBuilder {
-    experimental: None,
-    missing_runtime_behavior: Some(
-        Warn,
-    ),
-    always_keep_download: None,
-    always_keep_install: None,
-    legacy_version_file: None,
+    missing_runtime_behavior: Warn,
     legacy_version_file_disable_tools: {
         "disabled_tool_from_legacy_file",
     },
-    plugin_autoupdate_last_check_duration: None,
-    trusted_config_paths: {},
-    verbose: Some(
-        true,
-    ),
-    asdf_compat: None,
-    jobs: None,
-    shorthands_file: None,
-    disable_default_shorthands: None,
+    verbose: true,
     disable_tools: {
         "disabled_tool",
     },
-    log_level: None,
-    raw: None,
-    yes: None,
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -114,7 +114,7 @@ impl Settings {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct SettingsBuilder {
     pub experimental: Option<bool>,
     pub missing_runtime_behavior: Option<MissingRuntimeBehavior>,
@@ -252,6 +252,67 @@ impl SettingsBuilder {
 impl Display for Settings {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.to_index_map().fmt(f)
+    }
+}
+
+impl Debug for SettingsBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("SettingsBuilder");
+        if let Some(experimental) = self.experimental {
+            d.field("experimental", &experimental);
+        }
+        if let Some(missing_runtime_behavior) = &self.missing_runtime_behavior {
+            d.field("missing_runtime_behavior", &missing_runtime_behavior);
+        }
+        if let Some(always_keep_download) = self.always_keep_download {
+            d.field("always_keep_download", &always_keep_download);
+        }
+        if let Some(always_keep_install) = self.always_keep_install {
+            d.field("always_keep_install", &always_keep_install);
+        }
+        if let Some(legacy_version_file) = self.legacy_version_file {
+            d.field("legacy_version_file", &legacy_version_file);
+        }
+        if !self.legacy_version_file_disable_tools.is_empty() {
+            d.field(
+                "legacy_version_file_disable_tools",
+                &self.legacy_version_file_disable_tools,
+            );
+        }
+        if let Some(c) = self.plugin_autoupdate_last_check_duration {
+            d.field("plugin_autoupdate_last_check_duration", &c);
+        }
+        if !self.trusted_config_paths.is_empty() {
+            d.field("trusted_config_paths", &self.trusted_config_paths);
+        }
+        if let Some(verbose) = self.verbose {
+            d.field("verbose", &verbose);
+        }
+        if let Some(asdf_compat) = self.asdf_compat {
+            d.field("asdf_compat", &asdf_compat);
+        }
+        if let Some(jobs) = self.jobs {
+            d.field("jobs", &jobs);
+        }
+        if let Some(shorthands_file) = &self.shorthands_file {
+            d.field("shorthands_file", &shorthands_file);
+        }
+        if let Some(dds) = self.disable_default_shorthands {
+            d.field("disable_default_shorthands", &dds);
+        }
+        if !self.disable_tools.is_empty() {
+            d.field("disable_tools", &self.disable_tools);
+        }
+        if let Some(log_level) = self.log_level {
+            d.field("log_level", &log_level);
+        }
+        if let Some(raw) = self.raw {
+            d.field("raw", &raw);
+        }
+        if let Some(yes) = self.yes {
+            d.field("yes", &yes);
+        }
+        d.finish()
     }
 }
 


### PR DESCRIPTION
it might not look like it but this actually removes a massive amount of code since it doesn't rely on `rtx local` for its implementation. I may later refactor `rtx local|global` to also be more like this.