### PR TITLE
support RTX_ADD_PATH

### DIFF
--- a/src/cli/direnv/envrc.rs
+++ b/src/cli/direnv/envrc.rs
@@ -41,12 +41,16 @@ impl Envrc {
             writeln!(file, "watch_file {}", cf.to_string_lossy())?;
         }
         for (k, v) in ts.env(&config) {
-            writeln!(
-                file,
-                "export {}={}",
-                shell_escape::unix::escape(k.into()),
-                shell_escape::unix::escape(v.into()),
-            )?;
+            if k == "PATH" {
+                writeln!(file, "PATH_add {}", v)?;
+            } else {
+                writeln!(
+                    file,
+                    "export {}={}",
+                    shell_escape::unix::escape(k.into()),
+                    shell_escape::unix::escape(v.into()),
+                )?;
+            }
         }
         for path in ts.list_paths(&config).into_iter().rev() {
             writeln!(file, "PATH_add {}", path.to_string_lossy())?;


### PR DESCRIPTION
This is an env var that poetry/pipenv use to add VIRTUAL_ENV/bin to PATH
while not also creating shims for everything in there.

See https://github.com/jdx/rtx/issues/897
