### PR TITLE
(python plugin): fixes #1134

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -72,7 +72,7 @@ impl PythonPlugin {
     }
 
     fn python_path(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_short_path().join("bin/python")
+        tv.install_path().join("bin/python")
     }
 
     fn install_default_packages(

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -72,7 +72,7 @@ impl PythonPlugin {
     }
 
     fn python_path(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join("bin/python")
+        tv.install_short_path().join("bin/python")
     }
 
     fn install_default_packages(
@@ -85,7 +85,7 @@ impl PythonPlugin {
             return Ok(());
         }
         pr.set_message("installing default packages");
-        CmdLineRunner::new(&config.settings, self.python_path(tv))
+        CmdLineRunner::new(&config.settings, tv.install_path().join("bin/python"))
             .with_pr(pr)
             .arg("-m")
             .arg("pip")


### PR DESCRIPTION
Fixes #1134 .

According to my quick dig into python core plugin impl, `python_path()` that is used in  `PythonPlugin::install_default_package()` and `PythonPlugin::get_virtualenv()` may point outdated python path when upgrading python@latest.
With this fix `python_path()` returns path based on `ToolVersion::install_path()` to avoid pointing outdated path during upgrade.