### PR TITLE
use rtx-versions.jdx.dev to fetch remote versions

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -6,5 +6,36 @@
         <language minSize="55" name="Rust" />
       </Languages>
     </inspection_tool>
+    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://0.0.0.0" />
+          <option value="http://127.0.0.1" />
+          <option value="http://activemq.apache.org/schema/" />
+          <option value="http://cxf.apache.org/schemas/" />
+          <option value="http://java.sun.com/" />
+          <option value="http://javafx.com/fxml" />
+          <option value="http://javafx.com/javafx/" />
+          <option value="http://json-schema.org/draft" />
+          <option value="http://localhost" />
+          <option value="http://maven.apache.org/POM/" />
+          <option value="http://maven.apache.org/xsd/" />
+          <option value="http://primefaces.org/ui" />
+          <option value="http://rtx-versions.jdx.dev" />
+          <option value="http://schema.cloudfoundry.org/spring/" />
+          <option value="http://schemas.xmlsoap.org/" />
+          <option value="http://tiles.apache.org/" />
+          <option value="http://www.ibm.com/webservices/xsd" />
+          <option value="http://www.jboss.com/xml/ns/" />
+          <option value="http://www.jboss.org/j2ee/schema/" />
+          <option value="http://www.springframework.org/schema/" />
+          <option value="http://www.springframework.org/security/tags" />
+          <option value="http://www.springframework.org/tags" />
+          <option value="http://www.thymeleaf.org" />
+          <option value="http://www.w3.org/" />
+          <option value="http://xmlns.jcp.org/" />
+        </list>
+      </option>
+    </inspection_tool>
   </profile>
 </component>

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -10,7 +10,7 @@ use crate::config::Settings;
 use crate::github::GithubRelease;
 use crate::install_context::InstallContext;
 use crate::plugins::core::CorePlugin;
-use crate::plugins::Plugin;
+use crate::plugins::{Plugin, HTTP};
 use crate::toolset::{ToolVersion, ToolVersionRequest};
 use crate::ui::progress_report::ProgressReport;
 use crate::{file, http};
@@ -27,9 +27,12 @@ impl BunPlugin {
     }
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
-        let http = http::Client::new()?;
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(versions) => return Ok(versions),
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
         let releases: Vec<GithubRelease> =
-            http.json("https://api.github.com/repos/oven-sh/bun/releases?per_page=100")?;
+            HTTP.json("https://api.github.com/repos/oven-sh/bun/releases?per_page=100")?;
         let versions = releases
             .into_iter()
             .map(|r| r.tag_name)

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -11,7 +11,7 @@ use crate::config::{Config, Settings};
 use crate::github::GithubRelease;
 use crate::install_context::InstallContext;
 use crate::plugins::core::CorePlugin;
-use crate::plugins::Plugin;
+use crate::plugins::{Plugin, HTTP};
 use crate::toolset::{ToolVersion, ToolVersionRequest, Toolset};
 use crate::ui::progress_report::ProgressReport;
 use crate::{file, http};
@@ -28,9 +28,12 @@ impl DenoPlugin {
     }
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
-        let http = http::Client::new()?;
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(versions) => return Ok(versions),
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
         let releases: Vec<GithubRelease> =
-            http.json("https://api.github.com/repos/denoland/deno/releases?per_page=100")?;
+            HTTP.json("https://api.github.com/repos/denoland/deno/releases?per_page=100")?;
         let versions = releases
             .into_iter()
             .map(|r| r.name)

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -28,6 +28,10 @@ impl GoPlugin {
     }
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(versions) => return Ok(versions),
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
         CorePlugin::run_fetch_task_with_timeout(move || {
             let repo = &*env::RTX_GO_REPO;
             let output = cmd!("git", "ls-remote", "--tags", repo, "go*").read()?;

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -77,6 +77,10 @@ impl JavaPlugin {
     }
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(versions) => return Ok(versions),
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
         let versions = self
             .fetch_java_metadata("ga")?
             .iter()

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -63,6 +63,10 @@ impl PythonPlugin {
     }
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(versions) => return Ok(versions),
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
         self.install_or_update_python_build()?;
         let python_build_bin = self.python_build_bin();
         CorePlugin::run_fetch_task_with_timeout(move || {

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -141,6 +141,10 @@ impl RubyPlugin {
     }
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(versions) => return Ok(versions),
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
         self.update_build_tool()?;
         let ruby_build_bin = self.ruby_build_bin();
         let versions = CorePlugin::run_fetch_task_with_timeout(move || {


### PR DESCRIPTION
This should improve performance a tad and will also make rtx work better in cases where it does not have GITHUB_API_TOKEN set and is rate-limited on GitHub
