### PR TITLE
uninstall: allow uninstalling all matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ v20.0.0
   - [`rtx sync node <--brew|--nvm|--nodenv>`](#rtx-sync-node---brew--nvm--nodenv)
   - [`rtx sync python --pyenv`](#rtx-sync-python---pyenv)
   - [`rtx trust [OPTIONS] [CONFIG_FILE]`](#rtx-trust-options-config_file)
-  - [`rtx uninstall [OPTIONS] <TOOL@VERSION>...`](#rtx-uninstall-options-toolversion)
+  - [`rtx uninstall [OPTIONS] [TOOL@VERSION]...`](#rtx-uninstall-options-toolversion)
   - [`rtx upgrade [OPTIONS] [TOOL@VERSION]...`](#rtx-upgrade-options-toolversion)
   - [`rtx use [OPTIONS] [TOOL@VERSION]...`](#rtx-use-options-toolversion)
   - [`rtx version`](#rtx-version)
@@ -2630,15 +2630,15 @@ Examples:
   $ rtx trust
 ```
 
-### `rtx uninstall [OPTIONS] <TOOL@VERSION>...`
+### `rtx uninstall [OPTIONS] [TOOL@VERSION]...`
 
 ```text
 Removes runtime versions
 
-Usage: uninstall [OPTIONS] <TOOL@VERSION>...
+Usage: uninstall [OPTIONS] [TOOL@VERSION]...
 
 Arguments:
-  <TOOL@VERSION>...
+  [TOOL@VERSION]...
           Tool(s) to remove
 
 Options:

--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -3397,7 +3397,7 @@ _rtx() {
             return 0
             ;;
         rtx__uninstall)
-            opts="-a -n -j -q -r -v -y -h --all --dry-run --jobs --debug --log-level --trace --quiet --raw --verbose --yes --help <TOOL@VERSION>..."
+            opts="-a -n -j -q -r -v -y -h --all --dry-run --jobs --debug --log-level --trace --quiet --raw --verbose --yes --help [TOOL@VERSION]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/e2e/test_nodejs
+++ b/e2e/test_nodejs
@@ -30,7 +30,7 @@ rtx plugin uninstall nodejs
 RTX_DISABLE_TOOLS=node assert_not_contains "rtx plugins --core" "node"
 
 export RTX_NODE_BUILD=0
-rtx uninstall node
+rtx uninstall -a node
 rtx i node
 assert "rtx x -- node --version" "v20.0.0"
 # rtx uninstall node

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
 use std::fs::File;
+use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -407,6 +408,11 @@ impl Eq for dyn Plugin {}
 impl PartialEq for dyn Plugin {
     fn eq(&self, other: &Self) -> bool {
         self.get_type() == other.get_type() && self.name() == other.name()
+    }
+}
+impl Hash for dyn Plugin {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state)
     }
 }
 impl PartialOrd for dyn Plugin {

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -30,8 +30,8 @@ pub fn rebuild(config: &Config) -> Result<()> {
             make_symlink(&to, &from)?;
         }
         remove_missing_symlinks(plugin.clone())?;
-        // attempt to remove the installs dir (will fail if not empty)
-        let _ = file::remove_dir(&installs_dir);
+        // remove install dir if empty
+        file::remove_dir(&installs_dir)?;
     }
     Ok(())
 }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -1,5 +1,7 @@
+use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -13,7 +15,7 @@ use crate::plugins::{Plugin, PluginName};
 use crate::toolset::{ToolVersionOptions, ToolVersionRequest};
 
 /// represents a single version of a tool for a particular plugin
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct ToolVersion {
     pub request: ToolVersionRequest,
     pub plugin_name: PluginName,
@@ -241,6 +243,32 @@ impl ToolVersion {
 impl Display for ToolVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}@{}", &self.plugin_name, &self.version)
+    }
+}
+
+impl PartialEq for ToolVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.plugin_name == other.plugin_name && self.version == other.version
+    }
+}
+impl Eq for ToolVersion {}
+impl PartialOrd for ToolVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for ToolVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.plugin_name.cmp(&other.plugin_name) {
+            Ordering::Equal => self.version.cmp(&other.version),
+            o => o,
+        }
+    }
+}
+impl Hash for ToolVersion {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.plugin_name.hash(state);
+        self.version.hash(state);
     }
 }
 


### PR DESCRIPTION
With this change, `rtx uninstall node@20` will uninstall all node versions starting with "20". If multiple match, `--all` needs to be passed.

Fixes #1115