### PR TITLE
hook-env: keep prepended PATH entries in front

### DIFF
--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -43,8 +43,13 @@ cd .. && _rtx_hook
 test "$(node -v)" = "v20.0.0"
 assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/python/3.12.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/poetry/1.7.1/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 
+export PATH="PRE:$PATH"
+cd 18 && _rtx_hook
+test "$(node -v)" = "v18.0.0"
+assert_path "PRE:/root:ROOT/e2e/cwd:INSTALLS/node/18.0.0/bin:INSTALLS/python/3.12.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/poetry/1.7.1/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
+
 rtx shell node@18.0.0 && _rtx_hook
 test "$(node -v)" = "v18.0.0"
 
 rtx deactivate
-assert_path ""
+assert_path "PRE"

--- a/src/env.rs
+++ b/src/env.rs
@@ -67,6 +67,7 @@ pub static RTX_FETCH_REMOTE_VERSIONS_CACHE: Lazy<Option<Duration>> = Lazy::new(|
 /// used to prevent infinite loops
 pub static __RTX_SCRIPT: Lazy<bool> = Lazy::new(|| var_is_true("__RTX_SCRIPT"));
 pub static __RTX_DIFF: Lazy<EnvDiff> = Lazy::new(get_env_diff);
+pub static __RTX_ORIG_PATH: Lazy<Option<String>> = Lazy::new(|| var("__RTX_ORIG_PATH").ok());
 pub static CI: Lazy<bool> = Lazy::new(|| var_is_true("CI"));
 pub static PREFER_STALE: Lazy<bool> = Lazy::new(|| prefer_stale(&ARGS));
 /// essentially, this is whether we show spinners or build output on runtime install

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -15,6 +15,7 @@ impl Shell for Bash {
         }
         out.push_str(&formatdoc! {r#"
             export RTX_SHELL=bash
+            export __RTX_ORIG_PATH="$PATH"
 
             rtx() {{
               local command

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -20,6 +20,7 @@ impl Shell for Fish {
         // https://github.com/direnv/direnv/blob/cb5222442cb9804b1574954999f6073cc636eff0/internal/cmd/shell_fish.go#L14-L36
         out.push_str(&formatdoc! {r#"
             set -gx RTX_SHELL fish
+            set -gx __RTX_ORIG_PATH $PATH
 
             function rtx
               if test (count $argv) -eq 0

--- a/src/shell/snapshots/rtx__shell__bash__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__bash__tests__hook_init.snap
@@ -4,6 +4,7 @@ expression: "bash.activate(exe, true)"
 ---
 export PATH="/some/dir:$PATH"
 export RTX_SHELL=bash
+export __RTX_ORIG_PATH="$PATH"
 
 rtx() {
   local command

--- a/src/shell/snapshots/rtx__shell__bash__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__bash__tests__hook_init_nix.snap
@@ -3,6 +3,7 @@ source: src/shell/bash.rs
 expression: "bash.activate(exe, true)"
 ---
 export RTX_SHELL=bash
+export __RTX_ORIG_PATH="$PATH"
 
 rtx() {
   local command

--- a/src/shell/snapshots/rtx__shell__fish__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__fish__tests__hook_init.snap
@@ -4,6 +4,7 @@ expression: "fish.activate(exe, true)"
 ---
 fish_add_path -g /some/dir
 set -gx RTX_SHELL fish
+set -gx __RTX_ORIG_PATH $PATH
 
 function rtx
   if test (count $argv) -eq 0

--- a/src/shell/snapshots/rtx__shell__fish__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__fish__tests__hook_init_nix.snap
@@ -3,6 +3,7 @@ source: src/shell/fish.rs
 expression: "fish.activate(exe, true)"
 ---
 set -gx RTX_SHELL fish
+set -gx __RTX_ORIG_PATH $PATH
 
 function rtx
   if test (count $argv) -eq 0

--- a/src/shell/snapshots/rtx__shell__zsh__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__zsh__tests__hook_init.snap
@@ -4,6 +4,7 @@ expression: "zsh.activate(exe, true)"
 ---
 export PATH="/some/dir:$PATH"
 export RTX_SHELL=zsh
+export __RTX_ORIG_PATH="$PATH"
 
 rtx() {
   local command

--- a/src/shell/snapshots/rtx__shell__zsh__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__zsh__tests__hook_init_nix.snap
@@ -3,6 +3,7 @@ source: src/shell/zsh.rs
 expression: "zsh.activate(exe, true)"
 ---
 export RTX_SHELL=zsh
+export __RTX_ORIG_PATH="$PATH"
 
 rtx() {
   local command

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -19,6 +19,7 @@ impl Shell for Zsh {
         }
         out.push_str(&formatdoc! {r#"
             export RTX_SHELL=zsh
+            export __RTX_ORIG_PATH="$PATH"
 
             rtx() {{
               local command


### PR DESCRIPTION
With this change, if you manually run PATH="/foo:$PATH" in
your shell after activating rtx, rtx will keep "/foo" in front of its own PATH entries.
Fixes #863
