### PR TITLE
use cache directory for incomplete marker

### DIFF
--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -344,7 +344,7 @@ pub trait Plugin: Debug + Send + Sync {
     }
 
     fn incomplete_file_path(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join("incomplete")
+        tv.cache_path().join("incomplete")
     }
 }
 


### PR DESCRIPTION
this was here originally but was mistakenly moved during a refactor

Fixes #1156
