### PR TITLE
use: show warning if setting a version that will not be used

### DIFF
--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -85,6 +85,7 @@ jobs:
           RTX_GITHUB_BOT_TOKEN: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
           TEST_TRANCHE: ${{matrix.tranche}}
           TEST_TRANCHE_COUNT: 4
+          TEST_FULL: ${{github.ref_name == 'main' && '1' || '0'}}
         with:
           timeout_minutes: 30
           max_attempts: 2

--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -31,6 +31,7 @@ assert_path() {
   fi
 }
 
+rtx i && _rtx_hook
 test "$(node -v)" = "v20.0.0"
 assert_path "/root:ROOT/e2e/cwd:INSTALLS/node/20.0.0/bin:INSTALLS/python/3.12.0/bin:INSTALLS/tiny/3.1.0/bin:INSTALLS/poetry/1.7.1/bin:INSTALLS/shellcheck/0.9.0/bin:INSTALLS/shfmt/3.6.0/bin"
 assert "$FOO" "cd"

--- a/e2e/ruby/test_ruby
+++ b/e2e/ruby/test_ruby
@@ -7,7 +7,6 @@ source "$(dirname "$0")/../assert.sh"
 export RTX_EXPERIMENTAL=1
 export RTX_RUBY_DEFAULT_PACKAGES_FILE="$ROOT/e2e/.default-gems"
 export RTX_RUBY_VERBOSE_INSTALL=1
-export RTX_RAW=1
 
 if [ "${TEST_ALL:-}" != 1 ]; then
   exit
@@ -22,7 +21,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 EOF
 
-rtx i ruby
+rtx i ruby -v
 assert_contains "rtx x -- ruby --version" "ruby 3.2.2"
 
 rm Gemfile

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -33,7 +33,6 @@ run_test() {
 	echo "Running $TEST"
 	rm -f "$RTX_CONFIG_FILE"
 	cd "$(dirname "$TEST")"
-	rtx i
 
 	"./$(basename "$TEST")"
 }

--- a/e2e/test_bang
+++ b/e2e/test_bang
@@ -10,6 +10,7 @@ assert() {
 	fi
 }
 
+rtx i tiny
 rtx local tiny@sub-1:latest
 assert "rtx current tiny" "2.1.0"
 rtx local tiny@sub-1:lts

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -133,7 +133,8 @@ impl Toolset {
             }
         }
         let queue = Arc::new(Mutex::new(queue));
-        let jobs = match opts.raw {
+        let raw = opts.raw || config.settings.raw;
+        let jobs = match raw {
             true => 1,
             false => opts.jobs.unwrap_or(config.settings.jobs),
         };
@@ -156,7 +157,7 @@ impl Toolset {
                                         true,
                                     )?,
                                     pr: mpr.add(),
-                                    raw: opts.raw,
+                                    raw,
                                     force: opts.force,
                                 };
                                 t.install_version(ctx)?;


### PR DESCRIPTION
e.g.: `rtx use -g node@18` if there is a local .rtx.toml with node already defined
