### PR TITLE
README: Extra warning for Fish activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,12 +471,15 @@ echo 'eval "$(rtx activate zsh)"' >> "${ZDOTDIR-$HOME}/.zshrc"
 echo 'rtx activate fish | source' >> ~/.config/fish/config.fish
 ```
 
-> **Note:**
->
+> [!NOTE]
 > For homebrew and possibly other installs rtx is automatically activated so
 > this is not necessary.
 >
 > See [`RTX_FISH_AUTO_ACTIVATE=1`](#rtx_fish_auto_activate1) for more information.
+
+> [!WARNING]
+> Do not place the activation code inside the `if status --is-interactive` block
+> until you explicitly set the `RTX_FISH_AUTO_ACTIVATE` to zero.
 
 #### Nushell
 


### PR DESCRIPTION
Previously it was ok to have the `rtx activate fish | source` inside of an `if status --is-interactive` block, but not anymore. Most likely, it happened because of the auto-activation release. 

Now, it’ll give you the following error every time Fish initiates itself:

```text
fish: Unknown command: rtx
/opt/homebrew/share/fish/vendor_conf.d/rtx-activate.fish (line 2): 
  rtx activate fish | source
  ^~^
from sourcing file /opt/homebrew/share/fish/vendor_conf.d/rtx-activate.fish
	called on line 248 of file /opt/homebrew/Cellar/fish/3.6.4/share/fish/config.fish
from sourcing file /opt/homebrew/Cellar/fish/3.6.4/share/fish/config.fish
	called during startup
```

And I don’t think it’s a bug, but users must know it’s no longer a viable option. At least until the `RTX_FISH_AUTO_ACTIVATE` is not set to 0.

Also, sprinkled it with [GitHub alert formatting syntax][gh-md-alerts] a little.

[gh-md-alerts]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts