### PR TITLE
plugins: add rust core plugin

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -1,0 +1,23 @@
+# Rust in rtx
+
+The following are instructions for using the rust rtx core plugin. This is used when there isn't a
+git plugin installed named "rust".
+
+If you want to use [asdf-rust](https://github.com/asdf-community/asdf-rust)
+then use `rtx plugins install rust GIT_URL`.
+
+The code for this is inside the rtx repository at
+[`./src/plugins/core/rust.rs`](https://github.com/jdx/rtx/blob/main/src/plugins/core/rust.rs).
+
+## Usage
+
+The following installs the latest version of rust-1.74.x (if some version of 1.74.x is not already
+installed) and makes it the global default:
+
+```sh-session
+rtx use -g rust@1.74
+```
+
+## Configuration
+
+- `RTX_RUST_WITHOUT` [string]: comma-separated list of toolchain components to omit

--- a/src/cli/alias/ls.rs
+++ b/src/cli/alias/ls.rs
@@ -69,19 +69,20 @@ mod tests {
     #[test]
     fn test_alias_ls() {
         assert_cli_snapshot!("aliases", @r###"
-        java  lts          21   
-        node  lts          20   
-        node  lts-argon    4    
-        node  lts-boron    6    
-        node  lts-carbon   8    
-        node  lts-dubnium  10   
-        node  lts-erbium   12   
-        node  lts-fermium  14   
-        node  lts-gallium  16   
-        node  lts-hydrogen 18   
-        node  lts-iron     20   
-        tiny  lts          3.1.0
-        tiny  lts-prev     2.0.0
+        java  lts          21    
+        node  lts          20    
+        node  lts-argon    4     
+        node  lts-boron    6     
+        node  lts-carbon   8     
+        node  lts-dubnium  10    
+        node  lts-erbium   12    
+        node  lts-fermium  14    
+        node  lts-gallium  16    
+        node  lts-hydrogen 18    
+        node  lts-iron     20    
+        rust  stable       latest
+        tiny  lts          3.1.0 
+        tiny  lts-prev     2.0.0 
         tiny  my/alias     3.0
         "###);
     }

--- a/src/cli/alias/set.rs
+++ b/src/cli/alias/set.rs
@@ -41,19 +41,20 @@ pub mod tests {
         assert_cli!("alias", "set", "tiny", "my/alias", "3.0");
 
         assert_cli_snapshot!("aliases", @r###"
-        java  lts          21   
-        node  lts          20   
-        node  lts-argon    4    
-        node  lts-boron    6    
-        node  lts-carbon   8    
-        node  lts-dubnium  10   
-        node  lts-erbium   12   
-        node  lts-fermium  14   
-        node  lts-gallium  16   
-        node  lts-hydrogen 18   
-        node  lts-iron     20   
-        tiny  lts          3.1.0
-        tiny  lts-prev     2.0.0
+        java  lts          21    
+        node  lts          20    
+        node  lts-argon    4     
+        node  lts-boron    6     
+        node  lts-carbon   8     
+        node  lts-dubnium  10    
+        node  lts-erbium   12    
+        node  lts-fermium  14    
+        node  lts-gallium  16    
+        node  lts-hydrogen 18    
+        node  lts-iron     20    
+        rust  stable       latest
+        tiny  lts          3.1.0 
+        tiny  lts-prev     2.0.0 
         tiny  my/alias     3.0
         "###);
         reset_config();

--- a/src/cli/alias/unset.rs
+++ b/src/cli/alias/unset.rs
@@ -39,18 +39,19 @@ mod tests {
 
         assert_cli!("alias", "unset", "tiny", "my/alias");
         assert_cli_snapshot!("aliases", @r###"
-        java  lts          21   
-        node  lts          20   
-        node  lts-argon    4    
-        node  lts-boron    6    
-        node  lts-carbon   8    
-        node  lts-dubnium  10   
-        node  lts-erbium   12   
-        node  lts-fermium  14   
-        node  lts-gallium  16   
-        node  lts-hydrogen 18   
-        node  lts-iron     20   
-        tiny  lts          3.1.0
+        java  lts          21    
+        node  lts          20    
+        node  lts-argon    4     
+        node  lts-boron    6     
+        node  lts-carbon   8     
+        node  lts-dubnium  10    
+        node  lts-erbium   12    
+        node  lts-fermium  14    
+        node  lts-gallium  16    
+        node  lts-hydrogen 18    
+        node  lts-iron     20    
+        rust  stable       latest
+        tiny  lts          3.1.0 
         tiny  lts-prev     2.0.0
         "###);
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -231,6 +231,18 @@ pub static RTX_GO_SET_GOROOT: Lazy<Option<bool>> =
 pub static RTX_GO_SET_GOPATH: Lazy<Option<bool>> =
     Lazy::new(|| var_option_bool("RTX_GO_SET_GOPATH"));
 
+// rust
+pub static RTX_RUST_REPO: Lazy<String> = Lazy::new(|| {
+    var("RTX_RUST_REPO").unwrap_or_else(|_| "https://github.com/rust-lang/rust".into())
+});
+pub static RTX_RUST_WITHOUT: Lazy<Vec<String>> = Lazy::new(|| {
+    var("RTX_RUST_WITHOUT")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect()
+});
+
 fn get_env_diff() -> EnvDiff {
     let env = vars().collect::<HashMap<_, _>>();
     match env.get("__RTX_DIFF") {

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -21,6 +21,7 @@ use crate::plugins::core::java::JavaPlugin;
 use crate::plugins::core::node::NodePlugin;
 use crate::plugins::core::node_build::NodeBuildPlugin;
 use crate::plugins::core::ruby::RubyPlugin;
+use crate::plugins::core::rust::RustPlugin;
 use crate::plugins::Plugin;
 use crate::timeout::run_with_timeout;
 use crate::toolset::ToolVersion;
@@ -35,6 +36,7 @@ mod node;
 mod node_build;
 mod python;
 mod ruby;
+mod rust;
 
 pub type PluginMap = BTreeMap<String, Arc<dyn Plugin>>;
 
@@ -59,7 +61,8 @@ pub static CORE_PLUGINS: Lazy<PluginMap> = Lazy::new(|| {
 });
 
 pub static EXPERIMENTAL_CORE_PLUGINS: Lazy<PluginMap> = Lazy::new(|| {
-    let plugins: Vec<Arc<dyn Plugin>> = vec![Arc::new(ErlangPlugin::new())];
+    let plugins: Vec<Arc<dyn Plugin>> =
+        vec![Arc::new(ErlangPlugin::new()), Arc::new(RustPlugin::new())];
     plugins
         .into_iter()
         .map(|plugin| (plugin.name().to_string(), plugin))

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::Result;
+use itertools::Itertools;
+use versions::Versioning;
+
+use crate::cli::version::{ARCH, OS};
+use crate::cmd::CmdLineRunner;
+use crate::http::HTTP;
+use crate::install_context::InstallContext;
+use crate::plugins::{core::CorePlugin, Plugin};
+use crate::toolset::{ToolVersion, ToolVersionRequest};
+use crate::ui::progress_report::SingleReport;
+use crate::{env, file};
+
+#[derive(Debug)]
+pub struct RustPlugin {
+    core: CorePlugin,
+}
+
+impl RustPlugin {
+    pub fn new() -> Self {
+        Self {
+            core: CorePlugin::new("rust"),
+        }
+    }
+
+    fn fetch_remote_versions(&self) -> Result<Vec<String>> {
+        match self.core.fetch_remote_versions_from_rtx() {
+            Ok(Some(versions)) => return Ok(versions),
+            Ok(None) => {}
+            Err(e) => warn!("failed to fetch remote versions: {}", e),
+        }
+
+        CorePlugin::run_fetch_task_with_timeout(|| {
+            let repo = &*env::RTX_RUST_REPO;
+            let output = cmd!("git", "ls-remote", "--tags", repo).read()?;
+            let lines = output.split('\n');
+
+            let versions = lines
+                .map(|s| s.split("refs/tags/").last().unwrap_or_default().to_string())
+                .filter(|s| !s.is_empty())
+                .filter(|s| regex!(r"^1\.[0-9]+\.[0-9]+$").is_match(s))
+                .unique()
+                .sorted_by_cached_key(|s| (Versioning::new(s), s.to_string()))
+                .collect();
+
+            Ok(versions)
+        })
+    }
+
+    fn rustc_bin(&self, tv: &ToolVersion) -> PathBuf {
+        tv.install_path().join("bin/rustc")
+    }
+
+    fn test_rustc(&self, ctx: &InstallContext) -> Result<()> {
+        if env::RTX_RUST_WITHOUT.contains(&"rustc".into()) {
+            return Ok(());
+        }
+
+        ctx.pr.set_message("rustc -V".into());
+
+        CmdLineRunner::new(self.rustc_bin(&ctx.tv))
+            .with_pr(ctx.pr.as_ref())
+            .arg("-V")
+            .execute()
+    }
+
+    fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
+        let url = format!(
+            "https://static.rust-lang.org/dist/rust-{}-{}-{}.tar.gz",
+            tv.version,
+            arch(),
+            os()
+        );
+
+        let filename = url.split('/').last().unwrap();
+        let tarball_path = tv.download_path().join(filename);
+
+        pr.set_message(format!("downloading {}", &url));
+        HTTP.download_file(&url, &tarball_path)?;
+
+        // TODO: verify GPG signature
+
+        Ok(tarball_path)
+    }
+
+    fn install(&self, ctx: &InstallContext, tarball_path: &Path) -> Result<()> {
+        ctx.pr
+            .set_message(format!("installing {}", tarball_path.display()));
+
+        file::remove_all(ctx.tv.install_path())?;
+        file::create_dir_all(ctx.tv.install_path())?;
+        file::untar(tarball_path, &ctx.tv.download_path())?;
+
+        cmd!(
+            "sh",
+            "install.sh",
+            format!("--prefix={}", ctx.tv.install_path().display()),
+            format!("--without={}", env::RTX_RUST_WITHOUT.join(","))
+        )
+        .dir(
+            ctx.tv
+                .download_path()
+                .join(format!("rust-{}-{}-{}", ctx.tv.version, arch(), os())),
+        )
+        .stdout_null()
+        .run()?;
+
+        Ok(())
+    }
+
+    fn verify(&self, ctx: &InstallContext) -> Result<()> {
+        self.test_rustc(ctx)
+    }
+}
+
+impl Plugin for RustPlugin {
+    fn name(&self) -> &str {
+        "rust"
+    }
+
+    fn list_remote_versions(&self) -> Result<Vec<String>> {
+        self.core
+            .remote_version_cache
+            .get_or_try_init(|| self.fetch_remote_versions())
+            .cloned()
+    }
+
+    fn get_aliases(&self) -> Result<BTreeMap<String, String>> {
+        let aliases = [("stable", "latest")]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        Ok(aliases)
+    }
+
+    fn install_version_impl(&self, ctx: &InstallContext) -> Result<()> {
+        assert!(matches!(
+            &ctx.tv.request,
+            ToolVersionRequest::Version { .. }
+        ));
+
+        let tarball_path = self.download(&ctx.tv, ctx.pr.as_ref())?;
+        self.install(ctx, &tarball_path)?;
+        self.verify(ctx)?;
+
+        Ok(())
+    }
+}
+
+fn os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "apple-darwin"
+    } else if cfg!(target_os = "linux") {
+        "unknown-linux-gnu"
+    } else if cfg!(target_os = "freebsd") {
+        "unknown-freebsd"
+    } else if cfg!(target_os = "openbsd") {
+        "unknown-openbsd"
+    } else if cfg!(target_os = "netbsd") {
+        "unknown-netbsd"
+    } else {
+        &OS
+    }
+}
+
+fn arch() -> &'static str {
+    if cfg!(target_arch = "x86_64") || cfg!(target_arch = "amd64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm64") {
+        "aarch64"
+    } else if cfg!(target_arch = "x86")
+        || cfg!(target_arch = "i386")
+        || cfg!(target_arch = "i486")
+        || cfg!(target_arch = "i686")
+        || cfg!(target_arch = "i786")
+    {
+        "i686"
+    } else {
+        &ARCH
+    }
+}


### PR DESCRIPTION
Added an experimental core plugin for rust.

It's essentially a native implementation of the [asdf-rust](https://github.com/asdf-community/asdf-rust) plugin.

The only configuration currently is `RTX_RUST_WITHOUT` which is a carbon copy of the `RUST_WITHOUT` variable from asdf-rust.

This project is incredible! Thanks for all the hard work!