### PR TITLE
linux: use argv0 to find rtx bin

### DIFF
--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -21,7 +21,8 @@ assert() {
 assert_path() {
   local expected="$1"
   local actual="${PATH/%$orig_path/}"
-  actual="${actual/%:/}"
+  actual="${actual%:}"
+  actual="${actual%:}"
   actual="${actual//$ROOT/ROOT}"
   actual="${actual//$RTX_DATA_DIR\/installs/INSTALLS}"
   if [[ "$actual" != "$expected" ]]; then

--- a/src/cli/implode.rs
+++ b/src/cli/implode.rs
@@ -25,7 +25,7 @@ pub struct Implode {
 
 impl Implode {
     pub fn run(self) -> Result<()> {
-        let mut files = vec![&*dirs::DATA, &*dirs::CACHE, &*env::RTX_EXE];
+        let mut files = vec![&*dirs::DATA, &*dirs::CACHE, &*env::RTX_BIN];
         if self.config {
             files.push(&*dirs::CONFIG);
         }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -43,7 +43,7 @@ impl SelfUpdate {
             rtxprintln!("rtx is already up to date");
         }
         if !self.no_plugins {
-            cmd!(&*env::RTX_EXE, "plugins", "update").run()?;
+            cmd!(&*env::RTX_BIN, "plugins", "update").run()?;
         }
 
         Ok(())
@@ -98,7 +98,7 @@ impl SelfUpdate {
     }
 
     pub fn is_available() -> bool {
-        !std::fs::canonicalize(&*env::RTX_EXE)
+        !std::fs::canonicalize(&*env::RTX_BIN)
             .ok()
             .and_then(|p| p.parent().map(|p| p.to_path_buf()))
             .and_then(|p| p.parent().map(|p| p.to_path_buf()))

--- a/src/fake_asdf.rs
+++ b/src/fake_asdf.rs
@@ -17,7 +17,6 @@ pub fn setup() -> color_eyre::Result<PathBuf> {
             file::create_dir_all(&path)?;
             file::write(
                 &asdf_bin,
-                // rtx="${{RTX_EXE:-rtx}}"
                 formatdoc! {r#"
                 #!/bin/sh
                 rtx asdf "$@"

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -80,7 +80,7 @@ static INITIAL_ENV: Lazy<HashMap<OsString, OsString>> = Lazy::new(|| {
             "RTX_CACHE_DIR" => env::RTX_CACHE_DIR.to_string_lossy().to_string(),
             "RTX_CONCURRENCY" => num_cpus::get().to_string(),
             "RTX_DATA_DIR" => dirs::DATA.to_string_lossy().to_string(),
-            "RTX_EXE" => env::RTX_EXE.to_string_lossy().to_string(),
+            "RTX_EXE" => env::RTX_BIN.to_string_lossy().to_string(),
         })
         .into_iter()
         .map(|(k, v)| (k.into(), v.into())),

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -75,7 +75,7 @@ pub fn reshim(config: &Config, ts: &Toolset) -> Result<()> {
         })
         .lock();
 
-    let rtx_bin = file::which("rtx").unwrap_or(env::RTX_EXE.clone());
+    let rtx_bin = file::which("rtx").unwrap_or(env::RTX_BIN.clone());
 
     create_dir_all(&*dirs::SHIMS)?;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -79,7 +79,7 @@ pub fn replace_path(input: &str) -> String {
     input
         .replace(&path, "$PATH")
         .replace(&home, "~")
-        .replace(&*env::RTX_EXE.to_string_lossy(), "rtx")
+        .replace(&*env::RTX_BIN.to_string_lossy(), "rtx")
 }
 
 pub fn cli_run(args: &Vec<String>) -> eyre::Result<(String, String)> {


### PR DESCRIPTION
Direct paths cause failures when updating the CLI if the real path to the binary changes such as with homebrew that puts the version in the path.
