### PR TITLE
verbose: recommend --verbose over setting log level

### DIFF
--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -75,6 +75,7 @@ mod tests {
 
     #[test]
     fn test_fake_asdf_list() {
+        assert_cli!("uninstall", "--all", "tiny");
         assert_cli!("install", "tiny@1", "tiny@2");
         assert_cli!("asdf", "install", "tiny");
         assert_cli_snapshot!("asdf", "list", "tiny", @r###"

--- a/src/env.rs
+++ b/src/env.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use itertools::Itertools;
 use log::LevelFilter;
 use once_cell::sync::Lazy;
-
 use url::Url;
 
 use crate::duration::HOURLY;
@@ -360,10 +359,10 @@ fn log_level() -> LevelFilter {
     if var_is_true("RTX_QUIET") {
         set_var("RTX_LOG_LEVEL", "warn");
     }
-    if var_is_true("RTX_DEBUG") {
+    if var_is_true("RTX_DEBUG") || var_is_true("RTX_VERBOSE") {
         set_var("RTX_LOG_LEVEL", "debug");
     }
-    if var_is_true("RTX_TRACE") {
+    if var_is_true("RTX_TRACE") || var("RTX_VERBOSE").is_ok_and(|v| v == "2") {
         set_var("RTX_LOG_LEVEL", "trace");
     }
     let args = ARGS.read().unwrap();
@@ -380,7 +379,7 @@ fn log_level() -> LevelFilter {
                 set_var("RTX_LOG_LEVEL", level);
             }
         }
-        if arg == "--debug" || arg == "--verbose" || (arg == "-v" && args.len() > 1) {
+        if arg == "--debug" || arg == "--verbose" || (arg == "-v" && args.len() > 2) {
             set_var("RTX_LOG_LEVEL", "debug");
         }
         if arg == "--trace" || arg == "-vv" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,9 @@ fn main() -> Result<()> {
             display_friendly_err(err);
             exit(1);
         }
-        Err(err) => Err(err).suggestion("Run with RTX_DEBUG=1 for more information."),
+        Err(err) => {
+            Err(err).suggestion("Run with --verbose or RTX_VERBOSE=1 for more information.")
+        }
     }
 }
 


### PR DESCRIPTION
I am trying to simplify things and take out the concept of "log level". Instead it is just verbose/quiet.
