### PR TITLE
hook-env: added warning back for missing installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1700,6 +1700,9 @@ Options:
       --status
           Show "rtx: <PLUGIN>@<VERSION>" message when changing directories
 
+  -q, --quiet
+          Hide the warning when a tool is not installed
+
 Examples:
   $ eval "$(rtx activate bash)"
   $ eval "$(rtx activate zsh)"

--- a/README.md
+++ b/README.md
@@ -1701,7 +1701,7 @@ Options:
           Show "rtx: <PLUGIN>@<VERSION>" message when changing directories
 
   -q, --quiet
-          Hide the warning when a tool is not installed
+          Hide warnings such as when a tool is not installed
 
 Examples:
   $ eval "$(rtx activate bash)"

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -5,7 +5,7 @@ _rtx() {
   local ret=1
 
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_cmds' \
@@ -73,7 +73,7 @@ __rtx_alias_cmd() {
   _arguments -s -S \
     '(-p --plugin)'{-p,--plugin}'=[filter aliases by plugin]:plugin:__rtx_plugins' \
     '--no-header[Don'\''t show table header]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_alias_cmds' \
@@ -98,7 +98,7 @@ __rtx_alias_get_cmd() {
   _arguments -s -S \
     ':plugin:__rtx_plugins' \
     ':alias:__rtx_aliases' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -107,7 +107,7 @@ __rtx_alias_ls_cmd() {
   _arguments -s -S \
     '::plugin:__rtx_plugins' \
     '--no-header[Don'\''t show table header]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -117,7 +117,7 @@ __rtx_alias_set_cmd() {
     ':plugin:__rtx_plugins' \
     ':alias:__rtx_aliases' \
     ':value:' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -126,7 +126,7 @@ __rtx_alias_unset_cmd() {
   _arguments -s -S \
     ':plugin:__rtx_plugins' \
     ':alias:__rtx_aliases' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -134,21 +134,21 @@ __rtx_alias_unset_cmd() {
 __rtx_asdf_cmd() {
   _arguments -s -S \
     '*::args:_cmdambivalent' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_bin_paths_cmd] )) ||
 __rtx_bin_paths_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_cache_cmd] )) ||
 __rtx_cache_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_cache_cmds' \
@@ -169,7 +169,7 @@ return ret
 __rtx_cache_clear_cmd() {
   _arguments -s -S \
     '*::plugin:__rtx_plugins' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -177,7 +177,7 @@ __rtx_cache_clear_cmd() {
 __rtx_completion_cmd() {
   _arguments -s -S \
     '::shell:(bash fish zsh)' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -185,7 +185,7 @@ __rtx_completion_cmd() {
 __rtx_config_cmd() {
   _arguments -s -S \
     '--no-header[Do not print table header]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_config_cmds' \
@@ -207,7 +207,7 @@ return ret
 __rtx_config_generate_cmd() {
   _arguments -s -S \
     '(-o --output)'{-o,--output}'=[Output to file instead of stdout]:output:_files' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -215,7 +215,7 @@ __rtx_config_generate_cmd() {
 __rtx_config_ls_cmd() {
   _arguments -s -S \
     '--no-header[Do not print table header]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -223,21 +223,21 @@ __rtx_config_ls_cmd() {
 __rtx_current_cmd() {
   _arguments -s -S \
     '::plugin:__rtx_plugins' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_deactivate_cmd] )) ||
 __rtx_deactivate_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_direnv_cmd] )) ||
 __rtx_direnv_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_direnv_cmds' \
@@ -259,28 +259,28 @@ return ret
 (( $+functions[__rtx_direnv_activate_cmd] )) ||
 __rtx_direnv_activate_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_direnv_envrc_cmd] )) ||
 __rtx_direnv_envrc_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_direnv_exec_cmd] )) ||
 __rtx_direnv_exec_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_doctor_cmd] )) ||
 __rtx_doctor_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -292,7 +292,7 @@ __rtx_env_cmd() {
     '(-j --jobs)'{-j,--jobs}'=[Number of jobs to run in parallel]:jobs:' \
     '(-J --json)'{-J,--json}'[Output in JSON format]' \
     '--raw[Directly pipe stdin/stdout/stderr from plugin to user Sets --jobs=1]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -302,7 +302,7 @@ __rtx_env_vars_cmd() {
     '--file=[The TOML file to update]:file:_files' \
     '*--remove=[Remove the environment variable from config file]:remove:' \
     '*::env_vars:' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -314,7 +314,7 @@ __rtx_exec_cmd() {
     '(-C --cd)'{-C,--cd}'=[Change to this directory before executing the command]:cd:_directories' \
     '(-j --jobs)'{-j,--jobs}'=[Number of jobs to run in parallel]:jobs:' \
     '--raw[Directly pipe stdin/stdout/stderr from plugin to user Sets --jobs=1]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -326,7 +326,7 @@ __rtx_global_cmd() {
     '--fuzzy[Save fuzzy version to \`~/.tool-versions\`]' \
     '*--remove=[Remove the plugin(s) from ~/.tool-versions]:remove:' \
     '--path[Get the path of the global config file]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -344,7 +344,7 @@ __rtx_implode_cmd() {
   _arguments -s -S \
     '--config[Also remove config directory]' \
     '(-n --dry-run)'{-n,--dry-run}'[List directories that would be removed without actually removing them]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -356,7 +356,7 @@ __rtx_install_cmd() {
     '(-j --jobs)'{-j,--jobs}'=[Number of jobs to run in parallel]:jobs:' \
     '--raw[Directly pipe stdin/stdout/stderr from plugin to user Sets --jobs=1]' \
     '*'{-v,--verbose}'[Show installation output]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_latest_cmd] )) ||
@@ -364,7 +364,7 @@ __rtx_latest_cmd() {
   _arguments -s -S \
     ':tool:__rtx_tool_versions' \
     '(-i --installed)'{-i,--installed}'[Show latest installed instead of available version]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -374,7 +374,7 @@ __rtx_link_cmd() {
     ':tool:__rtx_tool_versions' \
     ':path:_directories' \
     '(-f --force)'{-f,--force}'[Overwrite an existing tool version if it exists]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -387,7 +387,7 @@ __rtx_local_cmd() {
     '--fuzzy[Save fuzzy version to \`.tool-versions\` e.g.\: \`rtx local --fuzzy node@20\` will save \`node 20\` to .tool-versions This is the default behavior unless RTX_ASDF_COMPAT=1]' \
     '*--remove=[Remove the plugin(s) from .tool-versions]:remove:' \
     '--path[Get the path of the config file]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -402,7 +402,7 @@ __rtx_ls_cmd() {
     '(-m --missing)'{-m,--missing}'[Display missing tool versions]' \
     '--prefix=[Display versions matching this prefix]:prefix:__rtx_prefixes' \
     '--no-header[Don'\''t display headers]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -412,7 +412,7 @@ __rtx_ls_remote_cmd() {
     '::plugin:__rtx_plugins' \
     '--all[Show all installed plugins and versions]' \
     '::prefix:__rtx_prefixes' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -420,7 +420,7 @@ __rtx_ls_remote_cmd() {
 __rtx_outdated_cmd() {
   _arguments -s -S \
     '*::tool:__rtx_tool_versions' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -430,7 +430,7 @@ __rtx_plugins_cmd() {
     '(-c --core)'{-c,--core}'[The built-in plugins only]' \
     '--user[List installed plugins]' \
     '(-u --urls)'{-u,--urls}'[Show the git url for each plugin]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_plugins_cmds' \
@@ -460,7 +460,7 @@ __rtx_plugins_install_cmd() {
     '(-f --force)'{-f,--force}'[Reinstall even if plugin exists]' \
     '(-a --all)'{-a,--all}'[Install all missing plugins]' \
     '*'{-v,--verbose}'[Show installation output]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_plugins_link_cmd] )) ||
@@ -469,7 +469,7 @@ __rtx_plugins_link_cmd() {
     ':name:' \
     '::path:_directories' \
     '(-f --force)'{-f,--force}'[Overwrite existing plugin]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -479,7 +479,7 @@ __rtx_plugins_ls_cmd() {
     '(-c --core)'{-c,--core}'[The built-in plugins only]' \
     '--user[List installed plugins]' \
     '(-u --urls)'{-u,--urls}'[Show the git url for each plugin]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -488,7 +488,7 @@ __rtx_plugins_ls_remote_cmd() {
   _arguments -s -S \
     '(-u --urls)'{-u,--urls}'[Show the git url for each plugin e.g.\: https\://github.com/rtx-plugins/rtx-nodejs.git]' \
     '--only-names[Only show the name of each plugin by default it will show a "*" next to installed plugins]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -498,7 +498,7 @@ __rtx_plugins_uninstall_cmd() {
     '*::plugin:__rtx_plugins' \
     '(-p --purge)'{-p,--purge}'[Also remove the plugin'\''s installs, downloads, and cache]' \
     '(-a --all)'{-a,--all}'[Remove all plugins]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -507,7 +507,7 @@ __rtx_plugins_update_cmd() {
   _arguments -s -S \
     '*::plugin:__rtx_plugins' \
     '(-j --jobs)'{-j,--jobs}'=[Number of jobs to run in parallel]:jobs:' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -516,14 +516,14 @@ __rtx_prune_cmd() {
   _arguments -s -S \
     '*::plugin:__rtx_plugins' \
     '(-n --dry-run)'{-n,--dry-run}'[Do not actually delete anything]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_reshim_cmd] )) ||
 __rtx_reshim_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -534,13 +534,13 @@ __rtx_self_update_cmd() {
     '--no-plugins[Disable auto-updating plugins]' \
     '(-y --yes)'{-y,--yes}'[Skip confirmation prompt]' \
     '::version:' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]'
 }
 (( $+functions[__rtx_settings_cmd] )) ||
 __rtx_settings_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_settings_cmds' \
@@ -564,14 +564,14 @@ return ret
 __rtx_settings_get_cmd() {
   _arguments -s -S \
     ':setting:__rtx_settings' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_settings_ls_cmd] )) ||
 __rtx_settings_ls_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -580,7 +580,7 @@ __rtx_settings_set_cmd() {
   _arguments -s -S \
     ':setting:__rtx_settings' \
     ':value:' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -588,7 +588,7 @@ __rtx_settings_set_cmd() {
 __rtx_settings_unset_cmd() {
   _arguments -s -S \
     ':setting:__rtx_settings' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -599,14 +599,14 @@ __rtx_shell_cmd() {
     '(-j --jobs)'{-j,--jobs}'=[Number of jobs to run in parallel]:jobs:' \
     '--raw[Directly pipe stdin/stdout/stderr from plugin to user Sets --jobs=1]' \
     '(-u --unset)'{-u,--unset}'[Removes a previously set version]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_sync_cmd] )) ||
 __rtx_sync_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]' \
     '1: :__rtx_sync_cmds' \
@@ -630,7 +630,7 @@ __rtx_sync_node_cmd() {
     '--brew[Get tool versions from Homebrew]' \
     '--nvm[Get tool versions from nvm]' \
     '--nodenv[Get tool versions from nodenv]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -638,7 +638,7 @@ __rtx_sync_node_cmd() {
 __rtx_sync_python_cmd() {
   _arguments -s -S \
     '--pyenv[Get tool versions from pyenv]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -647,7 +647,7 @@ __rtx_trust_cmd() {
   _arguments -s -S \
     '::config_file:_files' \
     '--untrust[No longer trust this config]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -657,7 +657,7 @@ __rtx_uninstall_cmd() {
     '*::installed_tool:__rtx_installed_tool_versions' \
     '(-a --all)'{-a,--all}'[Delete all installed versions]' \
     '(-n --dry-run)'{-n,--dry-run}'[Do not actually delete anything]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -669,7 +669,7 @@ __rtx_upgrade_cmd() {
     '(-j --jobs)'{-j,--jobs}'=[Number of jobs to run in parallel]:jobs:' \
     '(-i --interactive)'{-i,--interactive}'[Display multiselect menu to choose which tools to upgrade]' \
     '--raw[Directly pipe stdin/stdout/stderr from plugin to user Sets --jobs=1]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -686,14 +686,14 @@ __rtx_use_cmd() {
     '*--remove=[Remove the tool(s) from config file]:remove:' \
     '(-p --path)'{-p,--path}'=[Specify a path to a config file or directory If a directory is specified, it will look for .rtx.toml (default) or .tool-versions]:path:_files' \
     '--pin[Save exact version to config file]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
 (( $+functions[__rtx_version_cmd] )) ||
 __rtx_version_cmd() {
   _arguments -s -S \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -701,7 +701,7 @@ __rtx_version_cmd() {
 __rtx_where_cmd() {
   _arguments -s -S \
     ':tool:__rtx_tool_versions' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -712,7 +712,7 @@ __rtx_which_cmd() {
     '--plugin[Show the plugin name instead of the path]' \
     '--version[Show the version instead of the path]' \
     '(-t --tool)'{-t,--tool}'=[Use a specific tool@version]:tool:__rtx_tool_versions' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Suppress warnings and other non-error messages]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -64,7 +64,7 @@ __rtx_activate_cmd() {
   _arguments -s -S \
     '::shell_type:(bash fish nu xonsh zsh)' \
     '--status[Show "rtx\: <PLUGIN>@<VERSION>" message when changing directories]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Hide the warning when a tool is not installed]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -335,7 +335,7 @@ __rtx_hook_env_cmd() {
   _arguments -s -S \
     '(-s --shell)'{-s,--shell}'=[Shell type to generate script for]:shell:(bash fish nu xonsh zsh)' \
     '--status[Show "rtx\: <PLUGIN>@<VERSION>" message when changing directories]' \
-    '(-q --quiet)'{-q,--quiet}'[Suppress output]' \
+    '(-q --quiet)'{-q,--quiet}'[Hide the warning when a tool is not installed]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -64,7 +64,7 @@ __rtx_activate_cmd() {
   _arguments -s -S \
     '::shell_type:(bash fish nu xonsh zsh)' \
     '--status[Show "rtx\: <PLUGIN>@<VERSION>" message when changing directories]' \
-    '(-q --quiet)'{-q,--quiet}'[Hide the warning when a tool is not installed]' \
+    '(-q --quiet)'{-q,--quiet}'[Hide warnings such as when a tool is not installed]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }
@@ -335,7 +335,7 @@ __rtx_hook_env_cmd() {
   _arguments -s -S \
     '(-s --shell)'{-s,--shell}'=[Shell type to generate script for]:shell:(bash fish nu xonsh zsh)' \
     '--status[Show "rtx\: <PLUGIN>@<VERSION>" message when changing directories]' \
-    '(-q --quiet)'{-q,--quiet}'[Hide the warning when a tool is not installed]' \
+    '(-q --quiet)'{-q,--quiet}'[Hide warnings such as when a tool is not installed]' \
     '*'{-v,--verbose}'[Show extra output (use -vv for even more)]' \
     '(-y --yes)'{-y,--yes}'[Answer yes to all prompts]'
 }

--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -2339,7 +2339,7 @@ _rtx() {
             return 0
             ;;
         rtx__hook__env)
-            opts="-s -q -v -y -h --shell --status --debug --log-level --trace --quiet --verbose --yes --help"
+            opts="-s -q -v -y -h --shell --status --quiet --debug --log-level --trace --verbose --yes --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -41,6 +41,7 @@ complete -xc rtx -n "not $fssf $others" -a where -d 'Display the installation pa
 complete -xc rtx -n "not $fssf $others" -a which -d 'Shows the path that a bin name points to'
 
 # activate
+complete -kxc rtx -n "$fssf activate" -s q -l quiet -d 'Hide the warning when a tool is not installed'
 complete -kxc rtx -n "$fssf activate" -a "bash fish nu xonsh zsh" -d 'Shell type to generate the script for'
 complete -kxc rtx -n "$fssf activate" -l status -d 'Show "rtx: <PLUGIN>@<VERSION>" message when changing directories'
 

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -41,7 +41,7 @@ complete -xc rtx -n "not $fssf $others" -a where -d 'Display the installation pa
 complete -xc rtx -n "not $fssf $others" -a which -d 'Shows the path that a bin name points to'
 
 # activate
-complete -kxc rtx -n "$fssf activate" -s q -l quiet -d 'Hide the warning when a tool is not installed'
+complete -kxc rtx -n "$fssf activate" -s q -l quiet -d 'Hide warnings such as when a tool is not installed'
 complete -kxc rtx -n "$fssf activate" -a "bash fish nu xonsh zsh" -d 'Shell type to generate the script for'
 complete -kxc rtx -n "$fssf activate" -l status -d 'Show "rtx: <PLUGIN>@<VERSION>" message when changing directories'
 

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -1,7 +1,7 @@
 set -l fssf "__fish_seen_subcommand_from"
 
 # rtx
-complete -kxc rtx -s q -l quiet -d 'Suppress output'
+complete -kxc rtx -s q -l quiet -d 'Suppress warnings and other non-error messages'
 complete -kxc rtx -s v -l verbose -d 'Show extra output (use -vv for even more)'
 complete -kxc rtx -s y -l yes -d 'Answer yes to all prompts'
 set -l others activate alias bin-paths cache completion config current deactivate direnv doctor env env-vars exec implode install latest link ls ls-remote outdated plugins prune reshim self-update settings shell sync trust uninstall upgrade use version where which

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -39,7 +39,7 @@ pub struct Activate {
     #[clap(long)]
     status: bool,
 
-    /// Hide the warning when a tool is not installed
+    /// Hide warnings such as when a tool is not installed
     #[clap(long, short)]
     quiet: bool,
 }

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -39,8 +39,8 @@ pub struct Activate {
     #[clap(long)]
     status: bool,
 
-    /// noop
-    #[clap(long, short, hide = true)]
+    /// Hide the warning when a tool is not installed
+    #[clap(long, short)]
     quiet: bool,
 }
 
@@ -58,7 +58,14 @@ impl Activate {
         } else {
             env::RTX_BIN.clone()
         };
-        let output = shell.activate(&rtx_bin, self.status);
+        let mut flags = vec![];
+        if self.quiet {
+            flags.push(" --quiet");
+        }
+        if self.status {
+            flags.push(" --status");
+        }
+        let output = shell.activate(&rtx_bin, flags.join(""));
         rtxprint!("{output}");
 
         Ok(())

--- a/src/cli/args/quiet.rs
+++ b/src/cli/args/quiet.rs
@@ -8,7 +8,7 @@ impl Quiet {
         Arg::new("quiet")
             .short('q')
             .long("quiet")
-            .help("Suppress output")
+            .help("Suppress warnings and other non-error messages")
             .global(true)
             .overrides_with("verbose")
             .action(ArgAction::SetTrue)

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -10,12 +10,11 @@ use crate::config::Config;
 
 use crate::config::Settings;
 use crate::direnv::DirenvDiff;
-use crate::env::__RTX_DIFF;
+use crate::env::{TERM_WIDTH, __RTX_DIFF};
 use crate::env_diff::{EnvDiff, EnvDiffOperation};
 
 use crate::shell::{get_shell, ShellType};
 use crate::toolset::{Toolset, ToolsetBuilder};
-use crate::ui::truncate::screen_trunc;
 use crate::{env, hook_env};
 
 /// [internal] called by activate hook to update env vars directory change
@@ -76,12 +75,12 @@ impl HookEnv {
             .collect_vec();
         if !installed_versions.is_empty() {
             let status = installed_versions.into_iter().rev().join(" ");
-            rtxstatusln!("{}", screen_trunc(&status));
+            rtxstatusln!("{}", truncate_str(&status, TERM_WIDTH.max(60) - 5, "…"));
         }
         let env_diff = EnvDiff::new(&env::PRISTINE_ENV, config.env.clone()).to_patches();
         if !env_diff.is_empty() {
             let env_diff = env_diff.into_iter().map(patch_to_status).join(" ");
-            rtxstatusln!("{env_diff}");
+            rtxstatusln!("{}", truncate_str(&env_diff, TERM_WIDTH.max(60) - 5, "…"));
         }
     }
 
@@ -179,7 +178,7 @@ impl HookEnv {
             .join(", ");
         rtxwarn!(
             "missing: {}. Install with {}",
-            truncate_str(&versions, 40, "…"),
+            truncate_str(&versions, TERM_WIDTH.max(60) - 39, "…"),
             style("rtx install").yellow().for_stderr(),
         );
     }

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -30,7 +30,7 @@ pub struct HookEnv {
     #[clap(long)]
     status: bool,
 
-    /// Hide the warning when a tool is not installed
+    /// Hide warnings such as when a tool is not installed
     #[clap(long, short)]
     quiet: bool,
 }
@@ -169,7 +169,7 @@ impl HookEnv {
     }
     fn missing_versions_warning(&self, ts: &Toolset) {
         let missing = ts.list_missing_versions();
-        if missing.is_empty() || self.quiet {
+        if missing.is_empty() {
             return;
         }
         let versions = missing

--- a/src/env.rs
+++ b/src/env.rs
@@ -12,6 +12,7 @@ use url::Url;
 use crate::duration::HOURLY;
 use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvDiffPatches};
 use crate::file::replace_path;
+use crate::hook_env::{deserialize_watches, HookEnvWatches};
 
 pub static ARGS: RwLock<Vec<String>> = RwLock::new(vec![]);
 pub static SHELL: Lazy<String> = Lazy::new(|| var("SHELL").unwrap_or_else(|_| "sh".into()));
@@ -93,6 +94,12 @@ pub static RTX_FETCH_REMOTE_VERSIONS_CACHE: Lazy<Option<Duration>> = Lazy::new(|
 pub static __RTX_SCRIPT: Lazy<bool> = Lazy::new(|| var_is_true("__RTX_SCRIPT"));
 pub static __RTX_DIFF: Lazy<EnvDiff> = Lazy::new(get_env_diff);
 pub static __RTX_ORIG_PATH: Lazy<Option<String>> = Lazy::new(|| var("__RTX_ORIG_PATH").ok());
+pub static __RTX_WATCH: Lazy<Option<HookEnvWatches>> = Lazy::new(|| match var("__RTX_WATCH") {
+    Ok(raw) => deserialize_watches(raw)
+        .map_err(|e| rtxwarn!("Failed to deserialize __RTX_WATCH {e}"))
+        .ok(),
+    _ => None,
+});
 pub static CI: Lazy<bool> = Lazy::new(|| var_is_true("CI"));
 pub static PREFER_STALE: Lazy<bool> = Lazy::new(|| prefer_stale(&ARGS.read().unwrap()));
 /// essentially, this is whether we show spinners or build output on runtime install

--- a/src/env.rs
+++ b/src/env.rs
@@ -359,7 +359,7 @@ fn prefer_stale(args: &[String]) -> bool {
 
 fn log_level() -> LevelFilter {
     if var_is_true("RTX_QUIET") {
-        set_var("RTX_LOG_LEVEL", "warn");
+        set_var("RTX_LOG_LEVEL", "error");
     }
     if var_is_true("RTX_DEBUG") || var_is_true("RTX_VERBOSE") {
         set_var("RTX_LOG_LEVEL", "debug");
@@ -388,7 +388,7 @@ fn log_level() -> LevelFilter {
             set_var("RTX_LOG_LEVEL", "trace");
         }
         if arg == "--quiet" || arg == "-q" {
-            set_var("RTX_LOG_LEVEL", "warn");
+            set_var("RTX_LOG_LEVEL", "error");
         }
     }
     let log_level = var("RTX_LOG_LEVEL")

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -25,25 +25,16 @@ pub fn should_exit_early(watch_files: &[PathBuf]) -> bool {
         return false;
     }
     let watch_files = get_watch_files(watch_files);
-    match env::var("__RTX_WATCH") {
-        Ok(raw) => {
-            match deserialize_watches(raw) {
-                Ok(watches) => {
-                    if have_config_files_been_modified(&watches, watch_files) {
-                        return false;
-                    }
-                    if have_rtx_env_vars_been_modified(&watches) {
-                        return false;
-                    }
-                }
-                Err(e) => {
-                    debug!("error deserializing watches: {:?}", e);
-                    return false;
-                }
-            };
+    match &*env::__RTX_WATCH {
+        Some(watches) => {
+            if have_config_files_been_modified(watches, watch_files) {
+                return false;
+            }
+            if have_rtx_env_vars_been_modified(watches) {
+                return false;
+            }
         }
-        Err(_) => {
-            // __RTX_WATCH is not set
+        None => {
             return false;
         }
     };

--- a/src/output.rs
+++ b/src/output.rs
@@ -72,8 +72,10 @@ macro_rules! rtxstatusln {
 #[macro_export]
 macro_rules! rtxwarn {
     ($($arg:tt)*) => {{
-        let rtx = console::style("rtx ").yellow().for_stderr();
-        eprintln!("{}{}", rtx, format!($($arg)*));
+        if log_enabled!(log::Level::Warn) {
+            let rtx = console::style("rtx ").yellow().for_stderr();
+            eprintln!("{}{}", rtx, format!($($arg)*));
+        }
     }};
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -49,11 +49,30 @@ macro_rules! rtxstatusln {
         }};
     }
 
+#[cfg(test)]
+#[macro_export]
+macro_rules! rtxwarn {
+        ($($arg:tt)*) => {{
+            let mut stderr = $crate::output::tests::STDERR.lock().unwrap();
+            let rtx = console::style("rtx ").yellow().for_stderr();
+            stderr.push(format!("{}{}", rtx, format!($($arg)*)));
+        }};
+    }
+
 #[cfg(not(test))]
 #[macro_export]
 macro_rules! rtxstatusln {
     ($($arg:tt)*) => {{
         let rtx = console::style("rtx ").dim().for_stderr();
+        eprintln!("{}{}", rtx, format!($($arg)*));
+    }};
+}
+
+#[cfg(not(test))]
+#[macro_export]
+macro_rules! rtxwarn {
+    ($($arg:tt)*) => {{
+        let rtx = console::style("rtx ").yellow().for_stderr();
         eprintln!("{}{}", rtx, format!($($arg)*));
     }};
 }

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -6,10 +6,9 @@ use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 pub struct Bash {}
 
 impl Shell for Bash {
-    fn activate(&self, exe: &Path, status: bool) -> String {
+    fn activate(&self, exe: &Path, flags: String) -> String {
         let dir = exe.parent().unwrap();
         let exe = exe.to_string_lossy();
-        let status = if status { " --status" } else { "" };
         let mut out = String::new();
         if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             out.push_str(&format!("export PATH=\"{}:$PATH\"\n", dir.display()));
@@ -41,7 +40,7 @@ impl Shell for Bash {
 
             _rtx_hook() {{
               local previous_exit_status=$?;
-              eval "$(rtx hook-env{status} -s bash)";
+              eval "$(rtx hook-env{flags} -s bash)";
               return $previous_exit_status;
             }};
             if [[ ";${{PROMPT_COMMAND:-}};" != *";_rtx_hook;"* ]]; then

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -84,14 +84,14 @@ mod tests {
     fn test_hook_init() {
         let bash = Bash::default();
         let exe = Path::new("/some/dir/rtx");
-        assert_snapshot!(bash.activate(exe, true));
+        assert_snapshot!(bash.activate(exe, " --status".into()));
     }
 
     #[test]
     fn test_hook_init_nix() {
         let bash = Bash::default();
         let exe = Path::new("/nix/store/rtx");
-        assert_snapshot!(bash.activate(exe, true));
+        assert_snapshot!(bash.activate(exe, " --status".into()));
     }
 
     #[test]

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -6,10 +6,9 @@ use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 pub struct Fish {}
 
 impl Shell for Fish {
-    fn activate(&self, exe: &Path, status: bool) -> String {
+    fn activate(&self, exe: &Path, flags: String) -> String {
         let dir = exe.parent().unwrap();
         let exe = exe.to_string_lossy();
-        let status = if status { " --status" } else { "" };
         let description = "'Update rtx environment when changing directories'";
         let mut out = String::new();
 
@@ -53,14 +52,14 @@ impl Shell for Fish {
             end
 
             function __rtx_env_eval --on-event fish_prompt --description {description};
-                {exe} hook-env{status} -s fish | source;
+                {exe} hook-env{flags} -s fish | source;
 
                 if test "$rtx_fish_mode" != "disable_arrow";
                     function __rtx_cd_hook --on-variable PWD --description {description};
                         if test "$rtx_fish_mode" = "eval_after_arrow";
                             set -g __rtx_env_again 0;
                         else;
-                            {exe} hook-env{status} -s fish | source;
+                            {exe} hook-env{flags} -s fish | source;
                         end;
                     end;
                 end;
@@ -69,7 +68,7 @@ impl Shell for Fish {
             function __rtx_env_eval_2 --on-event fish_preexec --description {description};
                 if set -q __rtx_env_again;
                     set -e __rtx_env_again;
-                    {exe} hook-env{status} -s fish | source;
+                    {exe} hook-env{flags} -s fish | source;
                     echo;
                 end;
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -112,14 +112,14 @@ mod tests {
     fn test_hook_init() {
         let fish = Fish::default();
         let exe = Path::new("/some/dir/rtx");
-        assert_snapshot!(fish.activate(exe, true));
+        assert_snapshot!(fish.activate(exe, " --status".into()));
     }
 
     #[test]
     fn test_hook_init_nix() {
         let fish = Fish::default();
         let exe = Path::new("/nix/store/rtx");
-        assert_snapshot!(fish.activate(exe, true));
+        assert_snapshot!(fish.activate(exe, " --status".into()));
     }
 
     #[test]

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -53,7 +53,7 @@ impl Display for ShellType {
 }
 
 pub trait Shell {
-    fn activate(&self, exe: &Path, status: bool) -> String;
+    fn activate(&self, exe: &Path, flags: String) -> String;
     fn deactivate(&self) -> String;
     fn set_env(&self, k: &str, v: &str) -> String;
     fn unset_env(&self, k: &str) -> String;

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -21,10 +21,9 @@ impl<'a> Display for EnvOp<'a> {
 }
 
 impl Shell for Nushell {
-    fn activate(&self, exe: &Path, status: bool) -> String {
+    fn activate(&self, exe: &Path, flags: String) -> String {
         let dir = exe.parent().unwrap();
         let exe = exe.display();
-        let status = if status { " --status" } else { "" };
         let mut out = String::new();
 
         if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
@@ -85,7 +84,7 @@ impl Shell for Nushell {
           }}
             
           def --env rtx_hook [] {{
-            ^"{exe}" hook-env{status} -s nu
+            ^"{exe}" hook-env{flags} -s nu
               | parse vars
               | update-env
           }}

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -124,14 +124,14 @@ mod tests {
     fn test_hook_init() {
         let nushell = Nushell::default();
         let exe = Path::new("/some/dir/rtx");
-        assert_snapshot!(nushell.activate(exe, true));
+        assert_snapshot!(nushell.activate(exe, " --status".into()));
     }
 
     #[test]
     fn test_hook_init_nix() {
         let nushell = Nushell::default();
         let exe = Path::new("/nix/store/rtx");
-        assert_snapshot!(nushell.activate(exe, true));
+        assert_snapshot!(nushell.activate(exe, " --status".into()));
     }
 
     #[test]

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -130,14 +130,14 @@ mod tests {
     fn test_hook_init() {
         let xonsh = Xonsh::default();
         let exe = Path::new("/some/dir/rtx");
-        insta::assert_snapshot!(xonsh.activate(exe, true));
+        insta::assert_snapshot!(xonsh.activate(exe, " --status".into()));
     }
 
     #[test]
     fn test_hook_init_nix() {
         let xonsh = Xonsh::default();
         let exe = Path::new("/nix/store/rtx");
-        insta::assert_snapshot!(xonsh.activate(exe, true));
+        insta::assert_snapshot!(xonsh.activate(exe, " --status".into()));
     }
 
     #[test]

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -35,10 +35,9 @@ fn xonsh_escape_char(ch: char) -> Option<&'static str> {
 }
 
 impl Shell for Xonsh {
-    fn activate(&self, exe: &Path, status: bool) -> String {
+    fn activate(&self, exe: &Path, flags: String) -> String {
         let dir = exe.parent().unwrap();
         let exe = exe.display();
-        let status = if status { " --status" } else { "" };
         let mut out = String::new();
 
         // todo: xonsh doesn't update the environment that rtx relies on with $PATH.add even with $UPDATE_OS_ENVIRON (github.com/xonsh/xonsh/issues/3207)
@@ -63,7 +62,7 @@ impl Shell for Xonsh {
         // todo: subprocess instead of $() is a bit faster, but lose auto-color detection (use $FORCE_COLOR)
         out.push_str(&formatdoc! {r#"
             def listen_prompt(): # Hook Events
-              execx($({exe} hook-env{status} -s xonsh))
+              execx($({exe} hook-env{flags} -s xonsh))
 
             XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
             "#});

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -88,14 +88,14 @@ mod tests {
     fn test_hook_init() {
         let zsh = Zsh::default();
         let exe = Path::new("/some/dir/rtx");
-        assert_snapshot!(zsh.activate(exe, true));
+        assert_snapshot!(zsh.activate(exe, " --status".into()));
     }
 
     #[test]
     fn test_hook_init_nix() {
         let zsh = Zsh::default();
         let exe = Path::new("/nix/store/rtx");
-        assert_snapshot!(zsh.activate(exe, true));
+        assert_snapshot!(zsh.activate(exe, " --status".into()));
     }
 
     #[test]

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -7,10 +7,9 @@ use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 pub struct Zsh {}
 
 impl Shell for Zsh {
-    fn activate(&self, exe: &Path, status: bool) -> String {
+    fn activate(&self, exe: &Path, flags: String) -> String {
         let dir = exe.parent().unwrap();
         let exe = exe.to_string_lossy();
-        let status = if status { " --status" } else { "" };
         let mut out = String::new();
 
         // much of this is from direnv
@@ -44,7 +43,7 @@ impl Shell for Zsh {
             }}
 
             _rtx_hook() {{
-              eval "$({exe} hook-env{status} -s zsh)";
+              eval "$({exe} hook-env{flags} -s zsh)";
             }}
             typeset -ag precmd_functions;
             if [[ -z "${{precmd_functions[(r)_rtx_hook]+1}}" ]]; then

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,4 +2,3 @@ pub mod multi_progress_report;
 pub mod progress_report;
 pub mod prompt;
 pub mod table;
-pub mod truncate;

--- a/src/ui/truncate.rs
+++ b/src/ui/truncate.rs
@@ -1,6 +1,0 @@
-use crate::env::TERM_WIDTH;
-use std::borrow::Cow;
-
-pub fn screen_trunc(s: &str) -> Cow<str> {
-    console::truncate_str(s, *TERM_WIDTH, "…")
-}


### PR DESCRIPTION
Can be disabled with `rtx activate --quiet`
