### PR TITLE
perf: skip loading config object before launching command

### DIFF
--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -628,7 +628,7 @@ _rtx() {
 
     case "${cmd}" in
         rtx)
-            opts="-q -v -y -h -V --debug --log-level --trace --quiet --verbose --yes --help --version activate alias asdf bin-paths cache completion config current deactivate direnv doctor env env-vars exec global hook-env implode install latest link local ls ls-remote outdated plugins prune reshim settings shell sync trust uninstall upgrade use version where which render-completion render-help render-mangen self-update help"
+            opts="-q -v -y -h -V --debug --log-level --trace --quiet --verbose --yes --help --version activate alias asdf bin-paths cache completion config current deactivate direnv doctor env env-vars exec global hook-env implode install latest link local ls ls-remote outdated plugins prune reshim self-update settings shell sync trust uninstall upgrade use version where which render-completion render-help render-mangen help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1432,7 +1432,7 @@ _rtx() {
             return 0
             ;;
         rtx__help)
-            opts="activate alias asdf bin-paths cache completion config current deactivate direnv doctor env env-vars exec global hook-env implode install latest link local ls ls-remote outdated plugins prune reshim settings shell sync trust uninstall upgrade use version where which render-completion render-help render-mangen self-update help"
+            opts="activate alias asdf bin-paths cache completion config current deactivate direnv doctor env env-vars exec global hook-env implode install latest link local ls ls-remote outdated plugins prune reshim self-update settings shell sync trust uninstall upgrade use version where which render-completion render-help render-mangen help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/cli/bin_paths.rs
+++ b/src/cli/bin_paths.rs
@@ -10,8 +10,9 @@ use crate::toolset::ToolsetBuilder;
 pub struct BinPaths {}
 
 impl BinPaths {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let ts = ToolsetBuilder::new().build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let ts = ToolsetBuilder::new().build(&config)?;
         ts.warn_if_versions_missing();
         for p in ts.list_paths() {
             rtxprintln!("{}", p.display());

--- a/src/cli/config/generate.rs
+++ b/src/cli/config/generate.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::config::Settings;
+use crate::config::{Config, Settings};
 use crate::file;
 use crate::file::display_path;
 use clap::ValueHint;
@@ -17,6 +17,7 @@ pub struct ConfigGenerate {
 
 impl ConfigGenerate {
     pub fn run(self) -> Result<()> {
+        let _ = Config::try_get()?;
         let settings = Settings::try_get()?;
         settings.ensure_experimental()?;
         let doc = r#"

--- a/src/cli/config/ls.rs
+++ b/src/cli/config/ls.rs
@@ -22,9 +22,9 @@ pub struct ConfigLs {
 
 impl ConfigLs {
     pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let settings = Settings::try_get()?;
         settings.ensure_experimental()?;
-        let config = Config::try_get()?;
         let rows = config
             .config_files
             .values()

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -20,8 +20,9 @@ pub struct Current {
 }
 
 impl Current {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let ts = ToolsetBuilder::new().build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let ts = ToolsetBuilder::new().build(&config)?;
         match &self.plugin {
             Some(plugin_name) => {
                 let plugin_name = unalias_plugin(plugin_name);

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -14,7 +14,8 @@ use crate::shell::get_shell;
 pub struct Deactivate {}
 
 impl Deactivate {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         if !config.is_activated() {
             err_inactive()?;
         }

--- a/src/cli/direnv/mod.rs
+++ b/src/cli/direnv/mod.rs
@@ -39,10 +39,11 @@ impl Commands {
 }
 
 impl Direnv {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let cmd = self
             .command
             .unwrap_or(Commands::Activate(activate::DirenvActivate {}));
-        cmd.run(config)
+        cmd.run(&config)
     }
 }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -37,21 +37,22 @@ pub struct Env {
 }
 
 impl Env {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(&config)?;
         let opts = InstallOptions {
             force: false,
             jobs: self.jobs,
             raw: self.raw,
             latest_versions: false,
         };
-        ts.install_arg_versions(config, &opts)?;
+        ts.install_arg_versions(&config, &opts)?;
         ts.warn_if_versions_missing();
 
         if self.json {
-            self.output_json(config, ts)
+            self.output_json(&config, ts)
         } else {
-            self.output_shell(config, ts)
+            self.output_shell(&config, ts)
         }
     }
 

--- a/src/cli/env_vars.rs
+++ b/src/cli/env_vars.rs
@@ -35,7 +35,8 @@ pub struct EnvVars {
 }
 
 impl EnvVars {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         if self.remove.is_none() && self.env_vars.is_none() {
             for (key, value) in &config.env {
                 let source = config.env_sources.get(key).unwrap();

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -55,19 +55,20 @@ pub struct Exec {
 }
 
 impl Exec {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(&config)?;
         let opts = InstallOptions {
             force: false,
             jobs: self.jobs,
             raw: self.raw,
             latest_versions: false,
         };
-        ts.install_arg_versions(config, &opts)?;
+        ts.install_arg_versions(&config, &opts)?;
         ts.warn_if_versions_missing();
 
         let (program, args) = parse_command(&env::SHELL, &self.command, &self.c);
-        let env = ts.env_with_path(config);
+        let env = ts.env_with_path(&config);
 
         self.exec(program, args, env)
     }

--- a/src/cli/external.rs
+++ b/src/cli/external.rs
@@ -18,13 +18,9 @@ pub fn commands(config: &Config) -> Vec<Command> {
         .collect()
 }
 
-pub fn execute(
-    config: &Config,
-    plugin: &str,
-    args: &ArgMatches,
-    external_commands: Vec<Command>,
-) -> Result<()> {
-    if let Some(mut cmd) = external_commands
+pub fn execute(plugin: &str, args: &ArgMatches) -> Result<()> {
+    let config = Config::try_get()?;
+    if let Some(mut cmd) = commands(&config)
         .into_iter()
         .find(|c| c.get_name() == plugin)
     {

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -48,9 +48,10 @@ pub struct Global {
 }
 
 impl Global {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         local(
-            config,
+            &config,
             &global_file(),
             self.tool,
             self.remove,

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -44,10 +44,11 @@ pub struct Install {
 }
 
 impl Install {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         match &self.tool {
-            Some(runtime) => self.install_runtimes(config, runtime)?,
-            None => self.install_missing_runtimes(config)?,
+            Some(runtime) => self.install_runtimes(&config, runtime)?,
+            None => self.install_missing_runtimes(&config)?,
         }
 
         Ok(())

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -26,7 +26,8 @@ pub struct Latest {
 }
 
 impl Latest {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let mut prefix = match self.tool.tvr {
             None => self.asdf_version,
             Some(ToolVersionRequest::Version(_, version)) => Some(version),

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -33,7 +33,8 @@ pub struct Link {
 }
 
 impl Link {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let version = match self.tool.tvr {
             Some(ref tvr) => tvr.version(),
             None => bail!("must provide a version for {}", self.tool.style()),

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -54,14 +54,15 @@ pub struct Local {
 }
 
 impl Local {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let path = if self.parent {
             get_parent_path()?
         } else {
             get_path()
         };
         local(
-            config,
+            &config,
             &path,
             self.tool,
             self.remove,

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -64,14 +64,15 @@ pub struct Ls {
 }
 
 impl Ls {
-    pub fn run(mut self, config: &Config) -> Result<()> {
+    pub fn run(mut self) -> Result<()> {
+        let config = Config::try_get()?;
         self.plugin = self
             .plugin
             .or_else(|| self.plugin_flag.clone().map(|p| vec![p]))
             .map(|p| p.into_iter().map(|p| unalias_plugin(&p).into()).collect());
-        self.verify_plugin(config)?;
+        self.verify_plugin(&config)?;
 
-        let mut runtimes = self.get_runtime_list(config)?;
+        let mut runtimes = self.get_runtime_list(&config)?;
         if self.current || self.global {
             // TODO: global is a little weird: it will show global versions as the active ones even if
             // they're overridden locally

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -21,24 +21,25 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 pub struct LsRemote {
     /// Plugin to get versions for
     #[clap(value_name = "TOOL@VERSION", value_parser = ToolArgParser, required_unless_present = "all")]
-    plugin: Option<ToolArg>,
+    pub(crate) plugin: Option<ToolArg>,
 
     /// Show all installed plugins and versions
     #[clap(long, verbatim_doc_comment, conflicts_with_all = ["plugin", "prefix"])]
-    all: bool,
+    pub(crate) all: bool,
 
     /// The version prefix to use when querying the latest version
     /// same as the first argument after the "@"
     #[clap(verbatim_doc_comment)]
-    prefix: Option<String>,
+    pub(crate) prefix: Option<String>,
 }
 
 impl LsRemote {
-    pub fn run(self, config: &Config) -> Result<()> {
-        if let Some(plugin) = self.get_plugin(config)? {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        if let Some(plugin) = self.get_plugin(&config)? {
             self.run_single(plugin)
         } else {
-            self.run_all(config)
+            self.run_all(&config)
         }
     }
 

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -21,8 +21,9 @@ pub struct Outdated {
 }
 
 impl Outdated {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let mut ts = ToolsetBuilder::new().with_args(&self.tool).build(&config)?;
         let tool_set = self
             .tool
             .iter()

--- a/src/cli/plugins/mod.rs
+++ b/src/cli/plugins/mod.rs
@@ -69,7 +69,8 @@ impl Commands {
 }
 
 impl Plugins {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let cmd = self.command.unwrap_or(Commands::Ls(ls::PluginsLs {
             all: self.all,
             core: self.core,
@@ -78,6 +79,6 @@ impl Plugins {
             user: self.user,
         }));
 
-        cmd.run(config)
+        cmd.run(&config)
     }
 }

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -30,10 +30,11 @@ pub struct Prune {
 }
 
 impl Prune {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let ts = ToolsetBuilder::new().build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let ts = ToolsetBuilder::new().build(&config)?;
         let mut to_delete = ts
-            .list_installed_versions(config)?
+            .list_installed_versions(&config)?
             .into_iter()
             .map(|(p, tv)| (tv.to_string(), (p, tv)))
             .collect::<BTreeMap<String, (Arc<dyn Plugin>, ToolVersion)>>();
@@ -44,7 +45,7 @@ impl Prune {
 
         for cf in config.get_tracked_config_files()?.values() {
             let mut ts = cf.to_toolset().clone();
-            ts.resolve(config);
+            ts.resolve(&config);
             for (_, tv) in ts.list_current_versions() {
                 to_delete.remove(&tv.to_string());
             }

--- a/src/cli/render_completion.rs
+++ b/src/cli/render_completion.rs
@@ -4,7 +4,6 @@ use std::io::Cursor;
 use clap_complete::generate;
 use eyre::Result;
 
-use crate::cli::self_update::SelfUpdate;
 use crate::shell::completions;
 
 /// Generate shell completions
@@ -24,7 +23,7 @@ impl RenderCompletion {
     pub fn run(self) -> Result<()> {
         let shell = self.shell.or(self.shell_type).unwrap();
 
-        let mut cmd = crate::cli::Cli::command().subcommand(SelfUpdate::command());
+        let mut cmd = crate::cli::Cli::command();
 
         let script = match shell {
             clap_complete::Shell::Zsh => completions::zsh_complete(&cmd)?,

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -3,7 +3,6 @@ use console::strip_ansi_codes;
 use eyre::Result;
 use itertools::Itertools;
 
-use crate::cli::self_update::SelfUpdate;
 use crate::cli::Cli;
 
 use crate::file;
@@ -31,7 +30,6 @@ impl RenderHelp {
 
 fn render_commands() -> String {
     let mut cli = Cli::command()
-        .subcommand(SelfUpdate::command())
         .term_width(80)
         .max_term_width(80)
         .disable_help_subcommand(true)

--- a/src/cli/render_mangen.rs
+++ b/src/cli/render_mangen.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use eyre::Result;
 
-use crate::cli::self_update::SelfUpdate;
 use crate::cli::{version, Cli};
 
 /// internal command to generate markdown from help
@@ -15,7 +14,6 @@ pub struct RenderMangen {}
 impl RenderMangen {
     pub fn run(self) -> Result<()> {
         let cli = Cli::command()
-            .subcommand(SelfUpdate::command())
             .version(&*version::RAW_VERSION)
             .disable_colored_help(true);
 

--- a/src/cli/reshim.rs
+++ b/src/cli/reshim.rs
@@ -30,10 +30,11 @@ pub struct Reshim {
 }
 
 impl Reshim {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let ts = ToolsetBuilder::new().build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let ts = ToolsetBuilder::new().build(&config)?;
 
-        shims::reshim(config, &ts)
+        shims::reshim(&config, &ts)
     }
 }
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1,4 +1,3 @@
-use clap::Args;
 use color_eyre::Result;
 use console::style;
 use self_update::backends::github::{ReleaseList, Update};
@@ -34,6 +33,9 @@ pub struct SelfUpdate {
 
 impl SelfUpdate {
     pub fn run(self) -> Result<()> {
+        if !Self::is_available() && !self.force {
+            bail!("rtx is installed via a package manager, cannot update");
+        }
         let status = self.do_update()?;
 
         if status.updated() {
@@ -104,9 +106,5 @@ impl SelfUpdate {
             .and_then(|p| p.parent().map(|p| p.to_path_buf()))
             .map(|p| p.join("lib").join(".disable-self-update").exists())
             .unwrap_or_default()
-    }
-
-    pub fn command() -> clap::Command {
-        Self::augment_args(clap::Command::new("self-update"))
     }
 }

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::{eyre, Result};
 use serde_json::Value;
 use std::collections::BTreeMap;
 
-use crate::config::Settings;
+use crate::config::{Config, Settings};
 
 /// Show a current setting
 ///
@@ -19,6 +19,7 @@ pub struct SettingsGet {
 
 impl SettingsGet {
     pub fn run(self) -> Result<()> {
+        Config::try_get()?;
         let settings = Settings::try_get()?;
         let json = settings.to_string();
         let doc: BTreeMap<String, Value> = serde_json::from_str(&json)?;

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -2,7 +2,7 @@ use eyre::Result;
 use serde_json::Value;
 use std::collections::BTreeMap;
 
-use crate::config::Settings;
+use crate::config::{Config, Settings};
 
 /// Show current settings
 ///
@@ -16,6 +16,7 @@ pub struct SettingsLs {}
 
 impl SettingsLs {
     pub fn run(self) -> Result<()> {
+        Config::try_get()?;
         let settings = Settings::try_get()?;
         let json = settings.to_string();
         let doc: BTreeMap<String, Value> = serde_json::from_str(&json)?;

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -30,11 +30,12 @@ pub struct Uninstall {
 }
 
 impl Uninstall {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let tool_versions = if self.installed_tool.is_empty() && self.all {
-            self.get_all_tool_versions(config)?
+            self.get_all_tool_versions(&config)?
         } else {
-            self.get_requested_tool_versions(config)?
+            self.get_requested_tool_versions(&config)?
         };
         let tool_versions = tool_versions
             .into_iter()
@@ -64,9 +65,9 @@ impl Uninstall {
             }
         }
 
-        let ts = ToolsetBuilder::new().build(config)?;
-        shims::reshim(config, &ts).wrap_err("failed to reshim")?;
-        runtime_symlinks::rebuild(config)?;
+        let ts = ToolsetBuilder::new().build(&config)?;
+        shims::reshim(&config, &ts).wrap_err("failed to reshim")?;
+        runtime_symlinks::rebuild(&config)?;
 
         Ok(())
     }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -45,8 +45,9 @@ pub struct Upgrade {
 }
 
 impl Upgrade {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let ts = ToolsetBuilder::new().with_args(&self.tool).build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let ts = ToolsetBuilder::new().with_args(&self.tool).build(&config)?;
         let mut outdated = ts.list_outdated_versions();
         if self.interactive && !outdated.is_empty() {
             let tvs = self.get_interactive_tool_set(&outdated)?;
@@ -62,7 +63,7 @@ impl Upgrade {
         if outdated.is_empty() {
             info!("All tools are up to date");
         } else {
-            self.upgrade(config, outdated)?;
+            self.upgrade(&config, outdated)?;
         }
 
         Ok(())

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -78,8 +78,9 @@ pub struct Use {
 }
 
 impl Use {
-    pub fn run(self, config: &Config) -> Result<()> {
-        let mut ts = ToolsetBuilder::new().build(config)?;
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
+        let mut ts = ToolsetBuilder::new().build(&config)?;
         let mpr = MultiProgressReport::get();
         let versions = self
             .tool
@@ -94,7 +95,7 @@ impl Use {
             })
             .collect::<Result<Vec<_>>>()?;
         ts.install_versions(
-            config,
+            &config,
             versions.clone(),
             &mpr,
             &InstallOptions {
@@ -124,7 +125,7 @@ impl Use {
         }
 
         if self.global {
-            self.warn_if_hidden(config, cf.get_path());
+            self.warn_if_hidden(&config, cf.get_path());
         }
         for plugin_name in &self.remove {
             cf.remove_plugin(plugin_name);

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -28,14 +28,15 @@ pub struct Where {
 }
 
 impl Where {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(self) -> Result<()> {
+        let config = Config::try_get()?;
         let runtime = match self.tool.tvr {
             None => match self.asdf_version {
                 Some(version) => self.tool.with_version(&version),
                 None => {
                     let ts = ToolsetBuilder::new()
                         .with_args(&[self.tool.clone()])
-                        .build(config)?;
+                        .build(&config)?;
                     let v = ts
                         .versions
                         .get(&self.tool.plugin)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use once_cell::sync::{Lazy, OnceCell};
 use rayon::prelude::*;
 
-pub use settings::{Settings, SettingsPartial};
+pub use settings::Settings;
 
 use crate::config::config_file::legacy_version::LegacyVersionFile;
 use crate::config::config_file::rtx_toml::RtxToml;
@@ -23,7 +23,7 @@ use crate::shorthands::{get_shorthands, Shorthands};
 use crate::{dirs, env, file, hook_env};
 
 pub mod config_file;
-mod settings;
+pub mod settings;
 mod tracking;
 
 type AliasMap = BTreeMap<PluginName, BTreeMap<String, String>>;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -131,6 +131,32 @@ impl Settings {
         PARTIALS.write().unwrap().push(partial);
         *SETTINGS.write().unwrap() = None;
     }
+    pub fn add_cli_matches(m: &clap::ArgMatches) {
+        let mut s = SettingsPartial::empty();
+        if let Some(true) = m.get_one::<bool>("yes") {
+            s.yes = Some(true);
+        }
+        if let Some(true) = m.get_one::<bool>("quiet") {
+            s.quiet = Some(true);
+        }
+        if let Some(true) = m.get_one::<bool>("trace") {
+            s.log_level = Some("trace".to_string());
+        }
+        if let Some(true) = m.get_one::<bool>("debug") {
+            s.log_level = Some("debug".to_string());
+        }
+        if let Some(log_level) = m.get_one::<String>("log-level") {
+            s.log_level = Some(log_level.to_string());
+        }
+        if *m.get_one::<u8>("verbose").unwrap() > 0 {
+            s.verbose = Some(true);
+        }
+        if *m.get_one::<u8>("verbose").unwrap() > 1 {
+            s.log_level = Some("trace".to_string());
+        }
+        Self::add_partial(s);
+    }
+
     pub fn default_builder() -> Builder<Self> {
         let mut b = Self::builder().env();
         for partial in PARTIALS.read().unwrap().iter() {

--- a/src/env.rs
+++ b/src/env.rs
@@ -60,6 +60,7 @@ pub static RTX_BIN: Lazy<PathBuf> = Lazy::new(|| {
 });
 pub static ARGV0: Lazy<String> = Lazy::new(|| ARGS.read().unwrap()[0].to_string());
 pub static RTX_BIN_NAME: Lazy<&str> = Lazy::new(|| filename(&ARGV0));
+pub static RTX_LOG_FILE: Lazy<Option<PathBuf>> = Lazy::new(|| var_path("RTX_LOG_FILE"));
 pub static RTX_LOG_FILE_LEVEL: Lazy<Option<LevelFilter>> = Lazy::new(log_file_level);
 pub static RTX_FETCH_REMOTE_VERSIONS_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
     var_duration("RTX_FETCH_REMOTE_VERSIONS_TIMEOUT").unwrap_or(Duration::from_secs(10))

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -51,7 +51,7 @@ fn parse_shorthands_file(mut f: PathBuf) -> Result<Shorthands> {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::SettingsPartial;
+    use crate::config::settings::SettingsPartial;
     use confique::Partial;
     use pretty_assertions::assert_str_eq;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -88,10 +88,7 @@ pub fn cli_run(args: &Vec<String>) -> eyre::Result<(String, String)> {
     *env::ARGS.write().unwrap() = args.clone();
     STDOUT.lock().unwrap().clear();
     STDERR.lock().unwrap().clear();
-    let config = Config::try_get()?;
-    Cli::new_with_external_commands(&config)
-        .run(args)
-        .with_section(|| format!("{}", args.join(" ").header("Command:")))?;
+    Cli::run(args).with_section(|| format!("{}", args.join(" ").header("Command:")))?;
     let stdout = clean_output(STDOUT.lock().unwrap().join("\n"));
     let stderr = clean_output(STDERR.lock().unwrap().join("\n"));
 


### PR DESCRIPTION
Fixes #412

This makes rtx a lot faster when the config isn't needed—though sadly it _is_ needed for most things. It makes `rtx completion zsh` go from 3ms to 2ms on my machine though.

This paves the way for more perf improvements later. It'll also make things like `rtx doctor` work even if config loading fails.