### PR TITLE
config: simplify loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,9 +588,6 @@ python = {version='3.10', virtualenv='.venv'}
 # note this will only be used if the plugin does not already exist
 python = 'https://github.com/asdf-community/asdf-python'
 
-[settings] # project-local settings
-verbose = true
-
 [alias.node] # project-local aliases
 my_custom_node = '20'
 ```

--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -11,6 +11,7 @@ use color_eyre::eyre::{eyre, Result, WrapErr};
 use console::style;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
+use rayon::prelude::*;
 
 use crate::cache::CacheManager;
 use crate::config::{Config, Settings};
@@ -89,7 +90,7 @@ impl ExternalPlugin {
 
     pub fn list() -> Result<Vec<(String, Arc<dyn Plugin>)>> {
         Ok(file::dir_subdirs(&dirs::PLUGINS)?
-            .into_iter()
+            .into_par_iter()
             .map(|name| (name.clone(), Self::newa(name)))
             .collect())
     }


### PR DESCRIPTION
Moved the logic around to simplify the config loading process.
For now this removes the ability to have project local settings.

Fixes #735
