### PR TITLE
docs: correct env variable RTX_EXPERIMENTAL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,7 @@ This controls the output of `rtx run`. It can be one of:
 - `prefix` - (default if jobs > 1) print by line with the prefix of the task name
 - `interleave` - (default if jobs == 1) display stdout/stderr as it comes in
 
-#### `RTX_EXPERIMENTAL=1`
+#### `RTX_EXPERIMENTAL=true`
 
 Enables experimental features.
 


### PR DESCRIPTION
RTX_EXPERIMENTAL=1 setting this in .rtx.toml fails with:

```bash
rtx expected value of env.RTX_EXPERIMENTAL to be a string or bool, got: 1
rtx Run with --verbose or RTX_VERBOSE=1 for more information

```