### PR TITLE
docs: fix allowed values for `RTX_TASK_OUTPUT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,12 +999,12 @@ This will automatically answer yes or no to prompts. This is useful for scriptin
 
 Set to false to disable the "command not found" handler to autoinstall missing tool versions.
 
-#### `RTX_TASK_OUTPUT=prefix`
+#### `RTX_TASK_OUTPUT=Prefix`
 
 This controls the output of `rtx run`. It can be one of:
 
-- `prefix` - (default if jobs > 1) print by line with the prefix of the task name
-- `interleave` - (default if jobs == 1) display stdout/stderr as it comes in
+- `Prefix` - (default if jobs > 1) print by line with the prefix of the task name
+- `Interleave` - (default if jobs == 1) display stdout/stderr as it comes in
 
 #### `RTX_EXPERIMENTAL=true`
 


### PR DESCRIPTION
`rtx` panics if `RTX_TASK_OUTPUT` is not set to `Prefix` or `Interleave` ([here](https://github.com/jdx/rtx/blob/460e54772b2eda6bf75358c50ac6a694394c051d/src/cli/run.rs#L300-L301)).

Correcting the values in the readme as a stopgap solution.