### PR TITLE
env: added RTX_ENV_FILE config

### DIFF
--- a/e2e/.test-env2
+++ b/e2e/.test-env2
@@ -1,0 +1,1 @@
+TEST_ENV2=foo

--- a/e2e/test_env
+++ b/e2e/test_env
@@ -10,3 +10,4 @@ rtx i node@18.0.0
 eval "$(rtx env -s bash node@18.0.0)"
 assert "node -v" "v18.0.0"
 assert "rtx x -- env | grep FOO_FROM_FILE" "FOO_FROM_FILE=foo_from_file"
+RTX_ENV_FILE=.test-env2 assert "rtx x -- env | grep TEST_ENV2" "TEST_ENV2=foo"

--- a/src/cli/settings/snapshots/rtx__cli__settings__ls__tests__settings_ls.snap
+++ b/src/cli/settings/snapshots/rtx__cli__settings__ls__tests__settings_ls.snap
@@ -8,6 +8,7 @@ asdf_compat = false
 color = true
 disable_default_shorthands = false
 disable_tools = []
+env_file = null
 experimental = true
 jobs = 2
 legacy_version_file = true

--- a/src/cli/settings/snapshots/rtx__cli__settings__set__tests__settings_set.snap
+++ b/src/cli/settings/snapshots/rtx__cli__settings__set__tests__settings_set.snap
@@ -8,6 +8,7 @@ asdf_compat = false
 color = true
 disable_default_shorthands = false
 disable_tools = []
+env_file = null
 experimental = true
 jobs = 2
 legacy_version_file = false

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -46,6 +46,7 @@ mod tests {
         color = true
         disable_default_shorthands = false
         disable_tools = []
+        env_file = null
         experimental = true
         jobs = 2
         legacy_version_file = true

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__env-5.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__env-5.snap
@@ -13,6 +13,7 @@ RtxToml(/tmp/.rtx.toml):  {
         "debug": Null,
         "disable_default_shorthands": Null,
         "disable_tools": Null,
+        "env_file": Null,
         "experimental": Null,
         "jobs": Null,
         "legacy_version_file": Null,

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-2.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-2.snap
@@ -30,5 +30,6 @@ expression: cf.settings().unwrap()
   "task_output": null,
   "not_found_auto_install": null,
   "ci": null,
+  "env_file": null,
   "cd": null
 }

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-6.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-6.snap
@@ -15,6 +15,7 @@ RtxToml(~/fixtures/.rtx.toml): terraform@1.0.0, node@18 node@prefix:20 node@ref:
         "disable_tools": Array [
             String("disabled_tool"),
         ],
+        "env_file": Null,
         "experimental": Null,
         "jobs": Null,
         "legacy_version_file": Null,

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-5.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-5.snap
@@ -13,6 +13,7 @@ RtxToml(~/fixtures/.rtx.toml):  {
         "debug": Null,
         "disable_default_shorthands": Null,
         "disable_tools": Null,
+        "env_file": Null,
         "experimental": Null,
         "jobs": Null,
         "legacy_version_file": Null,

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__remove_alias-4.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__remove_alias-4.snap
@@ -13,6 +13,7 @@ RtxToml(/tmp/.rtx.toml):  {
         "debug": Null,
         "disable_default_shorthands": Null,
         "disable_tools": Null,
+        "env_file": Null,
         "experimental": Null,
         "jobs": Null,
         "legacy_version_file": Null,

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__remove_plugin-4.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__remove_plugin-4.snap
@@ -13,6 +13,7 @@ RtxToml(/tmp/.rtx.toml):  {
         "debug": Null,
         "disable_default_shorthands": Null,
         "disable_tools": Null,
+        "env_file": Null,
         "experimental": Null,
         "jobs": Null,
         "legacy_version_file": Null,

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__replace_versions-4.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__replace_versions-4.snap
@@ -13,6 +13,7 @@ RtxToml(/tmp/.rtx.toml): node@16.0.1 node@18.0.1 {
         "debug": Null,
         "disable_default_shorthands": Null,
         "disable_tools": Null,
+        "env_file": Null,
         "experimental": Null,
         "jobs": Null,
         "legacy_version_file": Null,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -62,6 +62,8 @@ pub struct Settings {
     pub not_found_auto_install: bool,
     #[config(env = "CI", default = false)]
     pub ci: bool,
+    #[config(env = "RTX_ENV_FILE")]
+    pub env_file: Option<PathBuf>,
     pub cd: Option<String>,
 }
 


### PR DESCRIPTION
This lets you set RTX_ENV_FILE=.env in order to always import a local env file if one exists.